### PR TITLE
Misc. IRC Fixes

### DIFF
--- a/optking/IRCfollowing.py
+++ b/optking/IRCfollowing.py
@@ -68,7 +68,7 @@ def Dq_IRC(oMolsys, E, f_q, H_q, s, dqGuess):
     G_prime = intcosMisc.Gmat(oMolsys.intcos, oMolsys.geom, oMolsys.masses)
     logger.debug("Mass-weighted Gmatrix at hypersphere point: \n" + printMatString(G_prime))
     G_prime_root = symmMatRoot(G_prime)
-    G_prime_inv = symmMatInv(G_prime)
+    G_prime_inv = symmMatInv(G_prime, redundant = True)
     G_prime_root_inv = symmMatRoot(G_prime_inv)
 
     logger.debug("G prime root matrix: \n" + printMatString(G_prime_root))
@@ -189,7 +189,7 @@ def Dq_IRC(oMolsys, E, f_q, H_q, s, dqGuess):
     # dq_M = (H_M - lambda I)^(-1) [lambda * p_M - g_M]
     LambdaI = np.identity(len(oMolsys.intcos))
     LambdaI = np.multiply(Lambda, LambdaI)
-    deltaQM = symmMatInv(np.subtract(H_M, LambdaI))
+    deltaQM = symmMatInv(np.subtract(H_M, LambdaI), redundant=True)
     deltaQM = np.dot(deltaQM, np.subtract(np.multiply(Lambda, p_M), g_M))
     logger.debug("dq_M to next geometry\n" + printArrayString(deltaQM))
 
@@ -250,7 +250,7 @@ def calcLagrangianDerivs(Lambda, HMEigValues, HMEigVects, g_M, p_M, s):
 def calcLineDistStep(oMolsys):
     G      = intcosMisc.Gmat(oMolsys.intcos, oMolsys.geom, oMolsys.masses)
     G_root = symmMatRoot(G)
-    G_inv  = symmMatInv(G_root)
+    G_inv  = symmMatInv(G_root, redundant = True)
     G_root_inv  = symmMatRoot(G_inv)
 
     rxn_Dq  = np.subtract(intcosMisc.qValues(oMolsys.intcos, oMolsys.geom), IRCdata.history.q())
@@ -274,7 +274,7 @@ def calcArcDistStep(oMolsys):
     # mass-weight
     G      = intcosMisc.Gmat(oMolsys.intcos, oMolsys.geom, oMolsys.masses)
     G_root = symmMatRoot(G)
-    G_inv  = symmMatInv(G_root)
+    G_inv  = symmMatInv(G_root, redundant = True)
     G_root_inv  = symmMatRoot(G_inv)
     p[:]    = np.multiply( 1.0/np.linalg.norm(p),    p )
     line[:] = np.multiply( 1.0/np.linalg.norm(line), line )

--- a/optking/IRCfollowing.py
+++ b/optking/IRCfollowing.py
@@ -139,7 +139,7 @@ def Dq_IRC(oMolsys, E, f_q, H_q, s, dqGuess):
     logger.debug("for Lagrangian %10.5f to  %10.5f" % (lb_lagrangian,up_lagrangian))
 
     # Calulate lambda using Householder method
-    prev_lambda = -999
+    prev_lambda = Lambda
     lagIter = 0
     Lambda = (lb_lambda + up_lambda)/2 # start in middle of coarse range
 

--- a/optking/convCheck.py
+++ b/optking/convCheck.py
@@ -13,7 +13,7 @@ import numpy as np
 from math import fabs
 
 from . import optparams as op
-from .linearAlgebra import absMax, rms, symmMatRoot
+from .linearAlgebra import absMax, rms, symmMatInv, symmMatRoot
 from .intcosMisc import Gmat, Bmat, qValues
 from .printTools import printArrayString, printMatString
 
@@ -45,7 +45,7 @@ def convCheck(iterNum, oMolsys, dq, f, energies, q_pivot=None):
 
     if op.Params.opt_type == 'IRC':
         G_m = Gmat(oMolsys.intcos, oMolsys.geom, oMolsys.masses)
-        G_m_inv = np.linalg.inv(G_m)
+        G_m_inv = symmMatInv(G_m, redundant = True)        
         q = qValues(oMolsys.intcos, oMolsys.geom)
         logger.info("Projecting out forces parallel to reaction path.")
 

--- a/optking/linearAlgebra.py
+++ b/optking/linearAlgebra.py
@@ -133,8 +133,8 @@ def symmMatRoot(A, Inverse=None):
     except LinAlgError:
         raise OptError("symmMatRoot: could not compute eigenvectors")
 
-    evals[ np.abs(evals) < 5*np.finfo(np.float).resolution ] = 0.0
-    evects[ np.abs(evects) < 5*np.finfo(np.float).resolution ] = 0.0
+    evals[ np.abs(evals) < 10*np.finfo(np.float).resolution ] = 0.0
+    evects[ np.abs(evects) < 10*np.finfo(np.float).resolution ] = 0.0
 
     rootMatrix = np.zeros((len(evals), len(evals)), float)
     if Inverse:

--- a/optking/optimize.py
+++ b/optking/optimize.py
@@ -138,8 +138,8 @@ def optimize(oMolsys, options_in, json_in=None):
                         vM = lowestEigenvectorSymmMat(H_q_m)
                         optimize_log.info(printArrayString(vM, title="Lowest evect of H_q_M"))
 
-                        # Un mass-weight vector.
-                        G_root_inv = symmMatInv(G_root)
+                        # Un mass-weight vector. Remember that we could have redundant coordinates.
+                        G_root_inv = symmMatInv(G_root, redundant=True)
                         v = np.dot(G_root_inv, vM)
 
                         if op.Params.irc_direction == 'BACKWARD':


### PR DESCRIPTION
This is _not_ ready for merge and is being PRd solely for convenience of @AlexHeide and for general information.

I'm trying to get an IRC but have been running into some bugs. So far, I've found and solved:
* When redundant coordinates are used, the IRC will have near-zero eigenvalues in the G matrix. These must be removed in inverse functions.
* Some numerical noise "eigenvalues" were not being removed, leading to small negative eigenvalues that should have been removed. The threshold for removal is now less strict.
* A bug in the solution of the Lambda equations has been fixed. After the coarse-graining step, Lambda could become approx -500 due to a mistake with setting the previous lambda in the bisection stage. That has been corrected.

The IRC code is still too buggy for my purposes. For some reason, the steps when trying to converge a point on a path oscillate. Sometimes the oscillations are damped, other times not. (The IRC promptly fails.) When I have that solved, I'll add it to the PR.