### PR TITLE
wrapper rework

### DIFF
--- a/optking/molsys.py
+++ b/optking/molsys.py
@@ -2,7 +2,10 @@ import json
 import logging
 
 import numpy as np
+
 import qcelemental as qcel
+from qcelemental.models import Molecule
+from qcelemental.util.serialization import json_dumps
 
 from . import frag
 from .exceptions import AlgError, OptError
@@ -263,12 +266,13 @@ class Molsys(object):
     
             """
             geom = [i for i in self.geom.flat]
-            qc_molecule = {"symbols": self.atom_symbols, "geometry": geom, "masses": self.masses.tolist(),
+            qc_mol = {"symbols": self.atom_symbols, "geometry": geom, "masses": self.masses.tolist(),
                            "molecular_multiplicity": self.multiplicity, 
                            #"molecular_charge": self.charge, Should be unnessecary
                            "fix_com": True, "fix_orientation": True}
-
-            return qc_molecule
+            qc_mol = Molecule(**qc_mol)
+            qc_mol = json.loads(json_dumps(qc_mol))
+            return qc_mol
     
 
     def consolidateFragments(self):

--- a/optking/optwrapper.py
+++ b/optking/optwrapper.py
@@ -1,78 +1,94 @@
 # wrapper for optking's optimize function for input by psi4API
 # creates a moleuclar system from psi4s and generates optkings options from psi4's lsit of options
-import os
 import logging
 import json
+import copy
 
 from qcelemental.util.serialization import json_dumps
 from qcelemental.models import OptimizationInput, OptimizationResult
 
 import optking
-
+from . import caseInsensitiveDict
 from . import molsys
+from . import optparams as op
 from .optimize import optimize
+from .compute_wrappers import QCEngineComputer, Psi4Computer
+from .printTools import welcome
+from . exceptions import OptError
 
+def optimize_psi4(calc_name, program='psi4'):
+    """
+    Wrapper for optimize.optimize() Looks for an active psi4 molecule and optimizes.
+    This is the written warning that Optking will try to use psi4 if no program is provided
 
-def optimize_psi4(calc_name, psi4_options, program='psi4'):
-    """ Wrapper for optimize.optimize() Looks for an active psi4 molecule and optimizes.
-        Optkings options can be set normally according to psi4 input syntax. Psi4's options must
-        be passed to optking as a dictionary see psiAPI for details.   
-
-        Warning. Meant to be depracted. Users should just use psi4.optimize available.
-        Optking will try to use Psi4 if no program is provided in options
-        Does not return a full OptimizationResult since an OptimizationInput was not provided.
-        Returns a trajectory and final molecule
-
-        Parameters
-        ----------
-        calcName: str
-            level of theory for optimization. eg MP2
-        qm_options: dict
-            all options for the desired quantum chemistry package.
-        program: str
-            program used for gradients, hessians...
-            
-        Returns
-        -------
-        opt_output: dict
-            dictionary serialized MOLSSI OptimizationResult.
-            see https://github.com/MolSSI/QCElemental/blob/master/qcelemental/models/procedures.py
-
-        Notes
-        -----
-        Must include basis in options dictionary. eg {'basis': 'sto-3g'} 
-
+    Parameters
+    ----------
+    calcName: str
+        level of theory for optimization. eg MP2
+    program: str
+        program used for gradients, hessians...
+ 
+    Returns
+    -------
+    opt_output: dict
+        dictionary serialized MOLSSI OptimizationResult.
+        see https://github.com/MolSSI/QCElemental/blob/master/qcelemental/models/procedures.py
     """
 
     import psi4
 
     logger = logging.getLogger(__name__)
+    logger.info(welcome())
+
     mol = psi4.core.get_active_molecule()
     oMolsys = molsys.Molsys.from_psi4_molecule(mol)
 
-    #Get optking options from psi4
+    #Get optking options and globals from psi4
+    #Look through optking module specific options first. If a global has already appeared
+    #in optking's options, don't include as a qc package option
+
     module_options = psi4.driver.p4util.prepare_options_for_modules()
-    keywords = {'OPTKING': {}}
+    all_options = psi4.core.get_global_option_list()
+    opt_keys = {'program': program}
+    qc_keys = {}
+
     optking_options = module_options['OPTKING']
     for opt, optval in optking_options.items():
         if optval['has_changed']:
-            keywords['OPTKING'][opt] = optval['value']
-    keywords['OPTKING'].update({'program': program})
+            opt_keys[opt.lower()] = optval['value']
 
-    #Combine all options for optking and the QC package together
+    for option in all_options:
+        if psi4.core.has_global_option_changed(option):
+            if option in opt_keys:
+                pass
+            else:
+                qc_keys[option.lower()] = psi4.core.get_global_option(option)
 
-    psi4_options_lower = {k.lower(): v for k, v in psi4_options.items()}
-    keywords.update({'QM': psi4_options_lower})
-    keywords['QM'].update({'method': calc_name})
-    logger.info(json.dumps(keywords, indent=2))
-    opt_output = optimize(oMolsys, keywords)
+    # Make a qcSchema OptimizationInput
+    opt_input = {"keywords": opt_keys,
+                 "initial_molecule": oMolsys.molsys_to_qc_molecule(),
+                 "input_specification": {
+                    "model": {
+                        'basis': qc_keys.pop('basis'),
+                        'method': calc_name},
+                    "driver": "gradient",
+                    "keywords": qc_keys}}
+    opt_input = OptimizationInput(**opt_input)
 
-    opt_output.update({"provenance": optking._optking_provenance_stamp})
-    opt_output["provenance"]["routine"] = "optimize_psi4"
+    # Remove numpy elements to allow at will json serialization
+    opt_input = json.loads(json_dumps(opt_input))
 
-    logger.debug(json.dumps(json.loads(json_dumps(opt_output)), indent=2))
-
-    return opt_output
+    try:
+        initialize_options(opt_keys)
+        computer = make_computer(opt_input)
+        opt_output = optimize(oMolsys, computer)
+    except OptError as error:
+        opt_input.update({"success": False, "error": {"error_type": error.err_type, "error_message": error.mesg}})
+    finally:
+        opt_input.update({"provenance": optking._optking_provenance_stamp})
+        opt_input["provenance"]["routine"] = "optimize_psi4"
+        opt_input.update(opt_output)
+        return opt_input
 
 def optimize_qcengine(opt_input):
     """ Try to optimize, find TS, or find IRC of the system as specifed by a QCSchema OptimizationInput.
@@ -82,27 +98,60 @@ def optimize_qcengine(opt_input):
         optimization_input: OptimizationInput, dict
             Pydantic Schema of the OptimizationInput model.
             see https://github.com/MolSSI/QCElemental/blob/master/qcelemental/models/procedures.py
-    
+
         Returns
         -------
         dict
-            
     """
-    
+
+    logger = logging.getLogger(__name__)
+    logger.info(welcome())
+
     if isinstance(opt_input, OptimizationInput):
-        opt_input = opt_input.dict()  # Could fail if numpy elements present. Shouldn't be. 
-        # replace with qcelemental.util.serialization method json_dumps(). Then use json.loads() if fails
- 
+        opt_input = json.loads(json_dumps(opt_input))  #Remove numpy elements turn into dictionary
+
     # Make basic optking molecular system
     oMolsys = molsys.Molsys.from_JSON_molecule(opt_input['initial_molecule'])
-    keywords = {'OPTKING': opt_input['keywords'], 'QM': {}}  # store optking keywords leave QM blank
-    qc_input = opt_input['input_specification']  # will be used to create a QCSchema AtomicInput
+    try:
+        initialize_options(opt_input['keywords'])
+        computer = make_computer(opt_input)
+        opt_output = optimize(oMolsys, computer)
+    except OptError:
+        opt_input.update({"success": False, "error": {"error_type": error.err_type, "error_message": error.mesg}})
+    finally:
+        opt_input.update(opt_output)
+        opt_input.update({'provenance': optking._optking_provenance_stamp})
+        opt_input['provenance']['routine'] = "optimize_qcengine"
+        return opt_input
 
-    opt_output = optimize(oMolsys, keywords, qc_input)
-    opt_input.update(opt_output)
-    opt_input.update({'provenance': optking._optking_provenance_stamp})
-    opt_input['provenance']['routine'] = "optimize_qcengine"
     # QCEngine.procedures.optking.py takes 'output_data', unpacks and creates Optimization Schema
     # from qcel.models.procedures.py
-    return opt_input
 
+
+def make_computer(opt_input: dict, computer_type='qc'): 
+
+    program = op.Params.program
+    # This gets updated so it shouldn't be a reference
+    molecule = copy.deepcopy(opt_input['initial_molecule'])
+    qc_input = opt_input['input_specification']
+    options = qc_input['keywords']
+    model = qc_input['model']
+
+    if computer_type == 'psi4':
+        # Please note that program is not used here
+        return Psi4Computer(molecule, model, options, program)
+    else:
+        return QCEngineComputer(molecule, model, options, program)
+
+def initialize_options(opt_keys):
+
+    logger = logging.getLogger(__name__)
+    userOptions = caseInsensitiveDict.CaseInsensitiveDict(opt_keys)
+    # Save copy of original user options. Commented out until it is used
+    # origOptions = copy.deepcopy(userOptions)
+
+    # Create full list of parameters from user options plus defaults.
+    logger.debug("\n\tProcessing user input options...\n")
+    op.Params = op.OptParams(userOptions)
+    # TODO we should make this just be a normal object and we should return it to the optimize method
+    logger.debug(str(op.Params))

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ omit =
 
 [yapf]
 # YAPF, in .style.yapf files this shows up as "[style]" header
+BASED_ON_sTYLE = PEP8
 COLUMN_LIMIT = 119
 INDENT_WIDTH = 4
 USE_TABS = False

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ if __name__ == "__main__":
         packages=setuptools.find_packages(),
         install_requires=[
             'numpy>=1.7',
-            'qcelemental>=0.7.0',
-            'qcengine>=0.9.0',
+            'qcelemental>=0.12.0',
+            'qcengine>=0.12.0',
         ],
         extras_require={
             'docs': [

--- a/tests/test_1-hooh.py
+++ b/tests/test_1-hooh.py
@@ -14,19 +14,25 @@ def test_B_dB_matrices():
     """)
 
     psi4.core.clean_options()
-    psi4options = {
-      'basis': 'cc-pvdz',
-      'g_convergence': 'gau_tight',
-      'scf_type': 'pk'
+
+    psi4_options = {
+        'basis': 'cc-pvdz',
+        'g_convergence': 'gau_tight',
+        'scf_type': 'pk',
+        'TEST_B': True,
+        'TEST_DERIVATIVE_B': True,
+        "G_CONVERGENCE": "gau_tight"
     }
 
-    
-    psi4.set_module_options('OPTKING', {'TEST_B': True, 'TEST_DERIVATIVE_B': True, "G_CONVERGENCE": "gau_tight"})
+    psi4.set_options(psi4_options)
 
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    json_output = optking.optimize_psi4('hf') # Uses default program (psi4)
     E = json_output['energies'][-1]
     nucenergy = json_output['trajectory'][-1]['properties']['nuclear_repulsion_energy']
 
+    assert 'test_b' in json_output['keywords']
+    assert 'test_derivative_b' in json_output['keywords']
+    assert "g_convergence" in json_output['keywords']
     assert psi4.compare_values(refnucenergy, nucenergy, 4, "Nuclear repulsion energy") #TEST
     assert psi4.compare_values(refenergy, E , 8, "Reference energy")           #TEST
 
@@ -47,11 +53,12 @@ def test_maxiter():
         'e_convergence': 1e-10,
         'd_convergence': 1e-10,
         'scf_type': 'PK',
-      'geom_maxiter': 2,
+        'geom_maxiter': 2,
     }
     psi4.set_options(psi4options)
 
-    json_output = optking.optimize_psi4('hf', psi4options)
+    json_output = optking.optimize_psi4('hf')
 
+    assert 'geom_maxiter' in json_output['keywords']
     assert "Maximum number of steps exceeded" in json_output['error']['error_message']
     assert "OptError" in json_output['error']['error_type']

--- a/tests/test_11-ts-hooh.py
+++ b/tests/test_11-ts-hooh.py
@@ -29,7 +29,7 @@ def test_hooh_TS():
 
     psi4.set_options(psi4options) 
 
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    json_output = optking.optimize_psi4('hf') # Uses default program (psi4)
     E = json_output['energies'][-1]
 
     assert psi4.compare_values(TORS_ENERGY, E, 6, "cc-pVDZ RHF transition-state opt. of HOOH (dihedral=180), energy") #TEST
@@ -53,7 +53,7 @@ def test_hooh_min():
     }
 
     psi4.set_options(psi4options)
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    json_output = optking.optimize_psi4('hf') # Uses default program (psi4)
     E = json_output['energies'][-1]
     assert psi4.compare_values(ZERO_TORS_ENERGY, E, 6, "cc-pVDZ RHF transition-state opt. of HOOH (dihedral=0), energy") #TEST
 

--- a/tests/test_2_hessians.py
+++ b/tests/test_2_hessians.py
@@ -20,14 +20,15 @@ def test_hess_every(every, expected):
         """)
     
     psi4.core.clean_options()
-    psi4options = {
+    psi4_options = {
         'basis': 'cc-pvdz',
         'scf_type': 'pk',
+        'g_convergence': 'gau_verytight',
+        'full_hess_every': every
     }
     
-    psi4.set_module_options('Optking', {'g_convergence': 'gau_verytight', 'full_hess_every': every})
-    
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    psi4.set_options(psi4_options)
+    json_output = optking.optimize_psi4('hf')  # Uses default program (psi4)
     E = json_output['energies'][-1]
     
     assert psi4.compare_values(expected, E, 8, "Final energy, every step Hessian")  # TEST
@@ -45,14 +46,15 @@ def test_hess_guess(guess, expected):
         """)
 
     psi4.core.clean_options()
-    psi4options = {
+    psi4_options = {
         'basis': 'cc-pvdz',
         'scf_type': 'pk',
+        'g_convergence': 'gau_verytight',
+        'intrafrag_hess': guess
     }
 
-    psi4.set_module_options('Optking', {'g_convergence': 'gau_verytight', 'intrafrag_hess': guess})
-
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    psi4.set_options(psi4_options)
+    json_output = optking.optimize_psi4('hf') # Uses default program (psi4)
     E = json_output['energies'][-1]
     print(f"Number of steps taken {len(json_output['trajectory'])}")
     assert psi4.compare_values(expected, E, 8, "Final energy, every step Hessian")  # TEST
@@ -69,14 +71,15 @@ def test_hess_update(update, expected):
         """)
 
     psi4.core.clean_options()
-    psi4options = {
+    psi4_options = {
         'basis': 'cc-pvdz',
         'scf_type': 'pk',
+        'g_convergence': 'gau_verytight', 
+        'hess_update': update
     }
 
-    psi4.set_module_options('Optking', {'g_convergence': 'gau_verytight', 'hess_update': update})
-
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    psi4.set_options(psi4_options)
+    json_output = optking.optimize_psi4('hf') # Uses default program (psi4)
     E = json_output['energies'][-1]
     
     print(f"Number of steps taken {len(json_output['trajectory'])}")

--- a/tests/test_4-h2o.py
+++ b/tests/test_4-h2o.py
@@ -14,16 +14,16 @@ def test_h2o_rfo(option, expected):
     """)
 
     psi4.core.clean_options()    
-    psi4options = {
-      'basis': 'cc-pvtz',
-      'e_convergence': '10',
-      'd_convergence': '10',
-      'scf_type': 'pk',  
+    psi4_options = {
+        'basis': 'cc-pvtz',
+        'e_convergence': '10',
+        'd_convergence': '10',
+        'scf_type': 'pk',
+        'step_type': option 
     }
 
-    psi4.set_module_options('Optking', {'step_type': option})
-    
-    json_output = optking.optimize_psi4('hf', psi4options) # Uses default program (psi4)
+    psi4.set_options(psi4_options)
+    json_output = optking.optimize_psi4('hf') # Uses default program (psi4)
     E = json_output['energies'][-1]
     
     assert psi4.compare_values(finalEnergy, E, 6, f"{option} Step Final Energy")                                #TEST

--- a/tests/test_frozen_cart_and_backstep.py
+++ b/tests/test_frozen_cart_and_backstep.py
@@ -66,18 +66,17 @@ def test_hooh_freeze_xyz_Hs(options, expected):
     """)
 
     psi4.core.clean_options()   
-    psi4options = {
-     'basis': 'cc-pvdz',
-    }
-    
-    psi4.set_module_options('Optking', {'opt_coordinates': 'cartesian',
-                                        'g_convergence': 'gau_tight',
-                                        'geom_maxiter': 20,
-                                        'consecutive_backsteps': 1})
-    
-    psi4.set_module_options('Optking', options)
+    psi4_options = {
+        'basis': 'cc-pvdz',
+        'opt_coordinates': 'cartesian',
+        'g_convergence': 'gau_tight',
+        'geom_maxiter': 20,
+        'consecutive_backsteps': 1}
 
-    json_output = optking.optimize_psi4('hf', psi4options)
+    psi4.set_options(psi4_options)
+    psi4.set_module_options("OPTKING", options)
+
+    json_output = optking.optimize_psi4('hf')
     thisenergy = json_output['energies'][-1]
     assert psi4.compare_values(expected, thisenergy, 6)  #TEST
 

--- a/tests/test_frozen_internals.py
+++ b/tests/test_frozen_internals.py
@@ -27,16 +27,16 @@ def test_frozen_coords(option, expected):
 
     psi4.core.clean_options()
    
-    psi4options = {
+    psi4_options = {
       'diis': 'false',
       'basis': 'cc-PVDZ',
       'scf_type': 'pk',
+      'print': 4,
     }
-
-    psi4.set_module_options('OPTKING', {"print": 4})
+    psi4.set_options(psi4_options)
     psi4.set_module_options('OPTKING', option)
     
-    json_output = optking.optimize_psi4('hf', psi4options)
+    json_output = optking.optimize_psi4('hf')
     thisenergy = json_output['energies'][-1]
     
     assert psi4.compare_values(expected, thisenergy, 7)  # TEST

--- a/tests/test_irc_hooh.py
+++ b/tests/test_irc_hooh.py
@@ -16,17 +16,15 @@ def test_hooh_irc():
     
     psi4.core.clean_options()
     
-    psi4_options = { 'basis': 'dzp',
-                     'scf_type': 'pk' }
-    
-    psi4.set_module_options( "OPTKING", {
-      "g_convergence": "gau_verytight",
-      'opt_type': 'irc',
-      'geom_maxiter': 20,
-      #'irc_direction': "backward"
-      } )
-    
-    json_output = optking.optimize_psi4('hf', psi4_options)
+    psi4_options = {
+        'basis': 'dzp',
+        'scf_type': 'pk',
+        "g_convergence": "gau_verytight",
+        'opt_type': 'irc',
+        'geom_maxiter': 20}
+   
+    psi4.set_options(psi4_options) 
+    json_output = optking.optimize_psi4('hf')
     
     IRC = json_output['extras']['irc_rxn_path']
     

--- a/tests/test_linesearch.py
+++ b/tests/test_linesearch.py
@@ -14,18 +14,18 @@ def test_linesearch():
     """)
 
     psi4.core.clean_options()
-    psi4options = {
-      'basis': 'cc-pvdz',
-      'd_convergence': 10
+    psi4_options = {
+        'basis': 'cc-pvdz',
+        'd_convergence': 10,
+        'geom_maxiter': 20,
+        'g_convergence': 'gau_tight'
     }
 
-    psi4.set_options(psi4options)
-    
-    psi4.set_module_options('OPTKING', {'step_type': 'linesearch',
-                                        'geom_maxiter': 20,
-                                        'g_convergence': 'gau_tight'})
+    psi4.set_options(psi4_options)
+    # For some reason this works but setting it through set_options throws an error 
+    psi4.set_module_options("OPTKING", {"step_type": "linesearch"})  
 
-    json_output = optking.optimize_psi4('mp2', psi4options)
+    json_output = optking.optimize_psi4('mp2')
     E = json_output['energies'][-1]
     nucenergy = json_output['trajectory'][-1]['properties']['nuclear_repulsion_energy']
     assert psi4.compare_values(nucenergy, nucenergy, 3, "Nuclear repulsion energy")  #TEST

--- a/tests/test_opt2_allene.py
+++ b/tests/test_opt2_allene.py
@@ -22,14 +22,15 @@ def test_opt2_allene():
 
     psi4.core.clean_options()
    
-    psi4options = {
+    psi4_options = {
       'basis': 'DZ',
       'e_convergence': 10,
       'd_convergence': 10,
       'scf_type': 'pk',
     }
+    psi4.set_options(psi4_options)
 
-    json_output = optking.optimize_psi4('hf', psi4options)
+    json_output = optking.optimize_psi4('hf')
     E = json_output['energies'][-1]
     nucenergy = json_output['trajectory'][-1]['properties']['nuclear_repulsion_energy']
     assert psi4.compare_values(refnucenergy, nucenergy, 2, "Nuclear repulsion energy")    #TEST
@@ -47,7 +48,8 @@ def test_opt2_allene():
      H -0.92  0.00    1.8
     """)
     
-    json_output = optking.optimize_psi4('hf', psi4options)
+    psi4.set_options(psi4_options)
+    json_output = optking.optimize_psi4('hf')
     E = json_output['energies'][-1]
     nucenergy = json_output['trajectory'][-1]['properties']['nuclear_repulsion_energy']
     assert psi4.compare_values(refnucenergy, nucenergy, 2, "Nuclear repulsion energy")    #TEST

--- a/tests/test_opt5-ch2.py
+++ b/tests/test_opt5-ch2.py
@@ -20,7 +20,7 @@ def test_ch2_with_dummy_atoms():
 
     psi4.core.clean_options() 
 
-    psi4options = {
+    psi4_options = {
       'reference': 'uhf',
       'basis': '6-31G(d,p)',
       'docc': [2, 0, 0, 1],
@@ -29,9 +29,9 @@ def test_ch2_with_dummy_atoms():
     }
 
  
-    psi4.set_options(psi4options)
+    psi4.set_options(psi4_options)
     
-    json_output = optking.optimize_psi4('hf', psi4options)
+    json_output = optking.optimize_psi4('hf')
     thisenergy = json_output['energies'][-1]
     nucenergy = json_output['trajectory'][-1]['properties']['nuclear_repulsion_energy']   
  

--- a/tests/test_opt7-hooh-fixed.py
+++ b/tests/test_opt7-hooh-fixed.py
@@ -29,17 +29,17 @@ def test_hooh_fixed_OH_stre(option, expected):
 
     psi4.core.clean_options()
 
-    psi4options = {
+    psi4_options = {
       'diis': 'false',
       'basis': 'cc-pvdz',
       'g_convergence': 'gau_verytight'
     }
     
-    psi4.set_options(psi4options)
+    psi4.set_options(psi4_options)
     
     psi4.set_module_options('Optking', option)
     
-    json_output = optking.optimize_psi4('hf', psi4options)
+    json_output = optking.optimize_psi4('hf')
     E = json_output['energies'][-1]
     assert psi4.compare_values(expected, E)  # TEST
 

--- a/tests/test_test1.py
+++ b/tests/test_test1.py
@@ -15,7 +15,7 @@ def test_opt1_h2o():
 
     psi4.core.clean_options()
 
-    psi4options = {
+    psi4_options = {
       'diis': False,
       'basis': 'sto-3g',
       'e_convergence': 10,
@@ -23,9 +23,9 @@ def test_opt1_h2o():
       'scf_type': 'pk'
     }    
 
-    psi4.set_options(psi4options)
+    psi4.set_options(psi4_options)
     
-    json_output = optking.optimize_psi4('hf', psi4options)
+    json_output = optking.optimize_psi4('hf')
     E = json_output['energies'][-1]
     nucenergy = json_output['trajectory'][-1]['properties']['nuclear_repulsion_energy']
     


### PR DESCRIPTION
- The two optwrappers take care of creating a `QCEngineComputer` or `Psi4Computer` and initializing `Params`
-  `optimize()` takes a molecular system and computer.
- `optimize_psi4` now works with psithon or psiAPI

Internally, an optimization can be thought of as requiring a molecular system and a computer. We could add the ability to take a serialized form of `Params` and `History` to allow for restarting optimizations. Currently `Params` is initialized in the optwrapper and `History` is created in `optimize()`

The `optimize_psi4` wrapper now finds options from `psi4.core` instead of being passed them. This is primarily for dev use, since King and I like psi input files. Old psi4 inputs should now work with optking by just importing optking and changing, for example, `psi4.optimize('hf')` to `optking.optimize_psi4('hf')`
