### PR TITLE
Travis CI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - source activate test
 
     # Extra upstream for testing
-  - conda install qcengine=0.12.0 ci-psi4 psi4 -c psi4/label/dev
+  - conda install ci-psi4 psi4 -c psi4/label/dev
   - conda install msgpack-python
 
     # Build and install package

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -1,6 +1,6 @@
 # Temporarily change directory to $HOME to install software
 pushd .
-cd $HOME
+cd "$HOME"
 
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -13,21 +13,39 @@ else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 fi
 MINICONDA_HOME=$HOME/miniconda
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q https://repo.continuum.io/miniconda/$MINICONDA
-if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-    echo "Miniconda MD5 mismatch"
-    exit 1
-fi
-bash $MINICONDA -b -p $MINICONDA_HOME
 
-# Configure miniconda
-export PIP_ARGS="-U"
-# New to conda >=4.4
-echo ". $MINICONDA_HOME/etc/profile.d/conda.sh" >> ~/.bashrc  # Source the profile.d file
-echo "conda activate" >> ~/.bashrc  # Activate conda
-source ~/.bashrc  # source file to get new commands
-conda config --set always_yes yes
-conda update --quiet conda
+echo "-- Installing latest Miniconda"
+if [ -d "$MINICONDA_HOME/bin" ]; then
+    echo "-- Miniconda latest version FOUND in cache"
+    
+    # Config settings are not saved in the cache
+    export PIP_ARGS="-U"
+    export PATH=$MINICONDA_HOME/bin:$PATH
+
+    conda config --set always_yes yes --set changeps1 no
+else
+    MINICONDA_MD5=$(wget -qO- https://repo.anaconda.com/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+    echo "-- Miniconda latest version NOT FOUND in cache"
+    wget -q https://repo.continuum.io/miniconda/$MINICONDA
+    if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+        echo "Miniconda MD5 mismatch"
+        exit 1
+    fi
+    # Travis creates the cached directories for us.
+    # This is problematic when wanting to install Anaconda for the first time...
+    rm -rf "$MINICONDA_HOME"
+    bash $MINICONDA -b -p "$MINICONDA_HOME"
+
+    # Configure miniconda
+    export PIP_ARGS="-U"
+    export PATH=$MINICONDA_HOME/bin:$PATH
+
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+
+    rm -f $MINICONDA
+fi
+echo "-- Done with latest Miniconda"
+
 # Restore original directory
 popd

--- a/tests/test_jsoninput.py
+++ b/tests/test_jsoninput.py
@@ -23,9 +23,9 @@ from qcelemental.models import OptimizationInput
 
 
 @pytest.mark.parametrize("inp,expected", [
-    ('jsoninput.json', (8.9064890670, -74.965901192))
+    ('jsoninput.json', (8.9064890670, -74.965901192)),
     ('json_betapinene.json', (568.2219045869, -383.38105559)),
-    ('json_hooh_frozen.json', (37.969354880, -150.786372411)),
+    ('json_hooh_frozen.json', (37.969354880, -150.786372411))
 ])
 def test_input_through_json(inp, expected):
     with open(os.path.join(os.path.dirname(__file__), inp)) as input_data:


### PR DESCRIPTION
Make Continuous Integration tests able to pass.

- [x] Fixes typo in test_jsoninput.py
- [x] Replace travis_ci/before_install.sh with script from MolSSI/QCEngine
    fixes a Miniconda MD5 mismatch error
