### PR TITLE
Passing along charge and multiplicity for fragments so we can do

### DIFF
--- a/optking/optimize.py
+++ b/optking/optimize.py
@@ -58,6 +58,8 @@ def optimize(oMolsys, computer):
         converged = False
         # oMolsys = make_internal_coords(oMolsys)
         if not oMolsys.intcos_present:
+            logger.debug("Molecular systems before make_internal_coords:")
+            logger.debug(str(oMolsys))
             make_internal_coords(oMolsys)
             logger.debug("Molecular systems after make_internal_coords:")
             logger.debug(str(oMolsys))
@@ -500,16 +502,16 @@ def make_internal_coords(oMolsys, params=None):
     """
     if params is None:
         params = op.Params
-    optimize_log = logging.getLogger(__name__)
-    optimize_log.debug("\t Adding internal coordinates to molecular system")
+    logger = logging.getLogger(__name__)
+    logger.debug("\t Adding internal coordinates to molecular system")
 
     # Use covalent radii to determine bond connectivity.
     connectivity = addIntcos.connectivity_from_distances(oMolsys.geom, oMolsys.Z)
-    optimize_log.debug("Connectivity Matrix\n" + print_mat_string(connectivity))
+    logger.debug("Connectivity Matrix\n" + print_mat_string(connectivity))
 
     if params.frag_mode == 'SINGLE':
         # Make a single, supermolecule.
-        oMolsys.consolidate_fragments()          # collapse into one frag (if > 1)
+        oMolsys.consolidate_fragments()     # collapse into one frag (if > 1)
         oMolsys.split_fragments_by_connectivity()  # separate by connectivity
         # increase connectivity until all atoms are connected
         oMolsys.augment_connectivity_to_single_fragment(connectivity)
@@ -551,6 +553,8 @@ def prepare_opt_output(oMolsys, computer, rxnpath=False, error=None):
     logger = logging.getLogger(__name__)
     logger.debug("Preparing OptimizationResult")
     # Get molecule from most recent step. Add provenance and fill in non-required fills. Turn back to dict
+    logger.debug("Final molsys before conversion to qc_molecule:")
+    logger.debug(oMolsys)
     final_molecule = oMolsys.molsys_to_qc_molecule()
 
     qc_output = {"schema_name": 'qcschema_optimization_output', "trajectory": computer.trajectory,

--- a/optking/optwrapper.py
+++ b/optking/optwrapper.py
@@ -95,6 +95,8 @@ def initialize_from_psi4(calc_name, program, computer_type, dertype=None, **xtra
     logger = logging.getLogger(__name__)
     mol = psi4.core.get_active_molecule()
     oMolsys = molsys.Molsys.from_psi4_molecule(mol)
+    logger.debug('Optking molsys from psi4.core.get_active_molecule():')
+    logger.debug( oMolsys )
 
     # Get optking options and globals from psi4
     # Look through optking module specific options first. If a global has already appeared
@@ -130,7 +132,8 @@ def initialize_from_psi4(calc_name, program, computer_type, dertype=None, **xtra
                          'method': calc_name},
                      "driver": "gradient",
                      "keywords": qc_keys}}
-    logger.debug("Creating OptimizationInput")
+    logger.debug("Creating OptimizationInput, Initial qc molecule from Molsys:")
+    logger.debug(opt_input["initial_molecule"])
 
     opt_input = OptimizationInput(**opt_input)
     # Remove numpy elements to allow at will json serialization

--- a/tests/test_openshell.py
+++ b/tests/test_openshell.py
@@ -1,0 +1,44 @@
+import psi4
+import optking
+
+def test_charged_anion():
+    no2 = psi4.geometry("""
+      -1 1
+      N  -0.0001995858  -0.8633595176   0.0000000000
+      O  -0.7026831726   0.4173795866   0.0000000000
+      O   0.7028810651   0.4175165407   0.0000000000
+    """)
+
+    psi4.core.clean_options()
+    psi4_options = {
+      'basis': 'cc-pvdz',
+    }
+    psi4.set_options(psi4_options)
+
+    json_output = optking.optimize_psi4('hf')
+
+    E = json_output['energies'][-1]
+    refenergy    = -203.894394347422
+    assert psi4.compare_values(refenergy, E, 6, "RHF singlet NO2- energy")   
+
+
+def test_neutral_triplet():
+    o2 = psi4.geometry("""
+      0 3
+      O
+      O 1 1.2
+    """)
+
+    psi4.core.clean_options()
+    psi4_options = {
+      'basis': 'cc-pvdz',
+      'reference': 'uhf',
+    }
+    psi4.set_options(psi4_options)
+
+    result = optking.optimize_psi4('hf')
+
+    E = result['energies'][-1]
+    REF_uhf    = -149.6318688
+    assert psi4.compare_values(REF_uhf, E, 6, "UHF triplet O2 Energy") #TEST
+


### PR DESCRIPTION
open-shell.  Although optking doesn't do the electronic structure
and so doesn't use multiplicity etc., it sends such information
through qcengine to external programs.  There is some ambiguity
as to whether a user would typically want us to use those fragments
in our representation and optimization.  In special cases of gradient
calculations involving multiple, unique fragments, it might
be easier to use the OptHelper class and feed gradients in that way.

- [x] First pass successfully does anions and triplets.
- [ ] Need to test serialization during/between steps to make sure we can export/import our molsys.
- [ ] Need to think through how to handle or warn about cases where the external gradients depend on things like fragment multiplicity but internally we are doing single molecule (for example). 