### PR TITLE
Irc patch

### DIFF
--- a/docs/source/convergence.rst
+++ b/docs/source/convergence.rst
@@ -59,3 +59,13 @@ loosening the `rms_force` threshold
          **Max Disp**, and **RMS Disp**) are fulfilled. To help with flat 
          potential surfaces, alternate convergence achieved when 100\ :math:`\times`\ *rms force* is less 
          than **RMS Force** criterion.
+
+IRC Convergence
+---------------
+
+The IRC algorithm uses slightly different convergence criteria since the step sizes are of a fixed distance.
+The optimization ends when the forces are opposite the forces of the previous step at a certain threshold < -0.7.
+Alternatively an increase in energy along the MEP with any negative overlap of the forces is sufficient.
+
+Individual points on the IRC are optimized in a constrained optimization (on a hypersphere of fixed radius) according
+to the convergence criteria of the table above.

--- a/optking/IRCdata.py
+++ b/optking/IRCdata.py
@@ -221,7 +221,12 @@ class IRCHistory(object):
 
     def test_for_irc_minimum(self, f_q, energy):
         """ Given current forces, checks if we are at/near a minimum
-        For now, checks if forces are opposite those are previous pivot point
+        Two checks are performed.
+        1. If forces are opposite those are previous pivot point
+            - The forces point in opposite directions due to stepping over the minima
+        2. If forces are have any negative overlap and the energy has increased.
+            - The minima has been stepped over but the forces are not exactly opposite
+            due to finite step size
         """
 
         unit_f = f_q / np.linalg.norm(f_q)  # current forces

--- a/optking/IRCdata.py
+++ b/optking/IRCdata.py
@@ -64,8 +64,8 @@ class IRCpoint(object):
             "f_q": self.f_q.tolist(),
             "f_x": self.f_x.tolist(),
             "energy": self.energy,
-            "q_pivot": self.q_pivot.tolist(),
-            "x_pivot": self.x_pivot.tolist(),
+            "q_pivot": self.q_pivot.tolist() if self.q_pivot is not None else [0] * len(self.q),
+            "x_pivot": self.x_pivot.tolist() if self.x_pivot is not None else [0] * len(self.x),
             "step_dist": self.step_dist,
             "arc_dist": self.arc_dist,
             "line_dist": self.line_dist,
@@ -106,7 +106,9 @@ class IRCHistory(object):
         d = {
             "irc_points": [point.to_dict() for point in self.irc_points],
             "go": self.go,
-            "atom_symbols": self.atom_symbols
+            "atom_symbols": self.atom_symbols,
+            "direction": self.__direction,
+            "step_size": self.__step_size
         }
         return d
 
@@ -117,6 +119,8 @@ class IRCHistory(object):
         irc_history.irc_points = [IRCpoint.from_dict(point) for point in d["irc_points"]]
         irc_history.go = d["go"]
         irc_history.atom_symbols = d["atom_symbols"]
+        irc_history.__direction = d["direction"]
+        irc_history.__step_size = d["step_size"]
         return irc_history 
 
     def add_irc_point(self, step_number, q_in, x_in, f_q, f_x, E, lineDistStep=0, arcDistStep=0):

--- a/optking/IRCdata.py
+++ b/optking/IRCdata.py
@@ -219,7 +219,7 @@ class IRCHistory(object):
         index = -1 if step is None else step
         return self.irc_points[index].step_dist
 
-    def test_for_irc_minimum(self, f_q):
+    def test_for_irc_minimum(self, f_q, energy):
         """ Given current forces, checks if we are at/near a minimum
         For now, checks if forces are opposite those are previous pivot point
         """
@@ -230,8 +230,11 @@ class IRCHistory(object):
         overlap = np.dot(unit_f, unit_f_rxn)
 
         logger.info("Overlap of forces with previous rxnpath point %8.4f" % overlap)
-
+        d_energy = energy - self.energy()
+        logger.info("Change in energy from last point %d", d_energy)
         if overlap < -0.7:
+            return True
+        elif overlap < 0.0 and d_energy > 0.0:
             return True
 
         # TODO  Look at line distance criterion when distances are working.

--- a/optking/IRCdata.py
+++ b/optking/IRCdata.py
@@ -56,21 +56,27 @@ class IRCpoint(object):
         self.q_pivot = q_p
         self.x_pivot = x_p
 
-    def dict_output(self):
+    def to_dict(self):
         s = {
-            "Step Number": self.step_number,
-            "Intco Values": self.q.tolist(),
-            "Geometry": self.x.tolist(),
-            "Internal Forces": self.f_q.tolist(),
-            "Cartesian Forces": self.f_x.tolist(),
-            "Energy": self.energy,
-            "Pivot Intco Values": self.q_pivot.tolist(),
-            "Pivot Geometry": self.x_pivot.tolist(),
-            "Step Distance": self.step_dist,
-            "Arc Distance": self.arc_dist,
-            "Line Distance": self.line_dist,
+            "step_number": self.step_number,
+            "q": self.q.tolist(),
+            "x": self.x.tolist(),
+            "f_q": self.f_q.tolist(),
+            "f_x": self.f_x.tolist(),
+            "energy": self.energy,
+            "q_pivot": self.q_pivot.tolist(),
+            "x_pivot": self.x_pivot.tolist(),
+            "step_dist": self.step_dist,
+            "arc_dist": self.arc_dist,
+            "line_dist": self.line_dist,
         }
         return s
+
+    @classmethod
+    def from_dict(cls, d):
+        for key in ["q", "x", "f_q", "f_x", "q_pivot", "x_pivot"]:
+            d[key] = np.asarray(d[key])
+        return cls(**d)
 
 
 class IRCHistory(object):
@@ -94,6 +100,24 @@ class IRCHistory(object):
     def set_step_size_and_direction(self, step_size, direction):
         self.__step_size = step_size
         self.__direction = direction
+
+    def to_dict(self):
+
+        d = {
+            "irc_points": [point.to_dict() for point in self.irc_points],
+            "go": self.go,
+            "atom_symbols": self.atom_symbols
+        }
+        return d
+
+    @classmethod
+    def from_dict(cls, d):
+        
+        irc_history = cls()
+        irc_history.irc_points = [IRCpoint.from_dict(point) for point in d["irc_points"]]
+        irc_history.go = d["go"]
+        irc_history.atom_symbols = d["atom_symbols"]
+        return irc_history 
 
     def add_irc_point(self, step_number, q_in, x_in, f_q, f_x, E, lineDistStep=0, arcDistStep=0):
         if len(self.irc_points) != 0:
@@ -308,7 +332,7 @@ class IRCHistory(object):
         # out += mol.print_simples(psi_outfile, qc_outfile)
 
     def rxnpath_dict(self):
-        rp = [self.irc_points[i].dict_output() for i in range(len(self.irc_points))]
+        rp = [self.irc_points[i].to_dict() for i in range(len(self.irc_points))]
         return rp
 
     def _project_forces(self, f_q, o_molsys):

--- a/optking/IRCfollowing.py
+++ b/optking/IRCfollowing.py
@@ -31,6 +31,25 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
         self.irc_history.set_atom_symbols(self.molsys.atom_symbols)
         self.irc_history.set_step_size_and_direction(self.params.irc_step_size, self.params.irc_direction)
 
+    def to_dict(self):
+
+        return {
+            "irc_step_number": self.irc_step_number,
+            "sub_step_number": self.sub_step_number,
+            "total_steps_taken": self.total_steps_taken,
+            "irc_history": self.irc_history.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, d, molsys, history, params):
+
+        irc = cls(molsys, history, params)
+        irc.irc_step_number = d["irc_step_number"]
+        irc.sub_step_number = d["sub_step_number"]
+        irc.total_steps_taken = d["total_steps_taken"]
+        irc.irc_history = IRCdata.IRCHistory.from_dict(d.get("irc_history"))
+        return irc
+
     def requires(self):
 
         return "energy", "gradient", "hessian"

--- a/optking/convcheck.py
+++ b/optking/convcheck.py
@@ -244,7 +244,7 @@ def _print_convergence_table(conv_info, criteria, conv_met, conv_active, params_
     if conv_info.get('step_type') == 'standard':
         conv_str += std_vals.format(*print_vals)
     else:
-        print_vals = print_vals[:1] + [conv_info.get('sub_step_num')] + print_vals[1:]
+        print_vals = print_vals[:1] + [conv_info['sub_step_num']] + print_vals[1:]
         conv_str += irc_vals.format(*print_vals)
 
     conv_str += "\t" + "-" * dash_length + "\n\n"

--- a/optking/linesearch.py
+++ b/optking/linesearch.py
@@ -62,7 +62,38 @@ class LineSearch(OptimizationInterface):
         if params.linesearch_step is None:
             self.step_size = np.linalg.norm(self.history[-2].Dq) / 2
 
-    @abstractmethod
+    def to_dict(self):
+        
+        return {
+            "linesearch_max_iter": self.linesearch_max_iter,
+            "linesearch_start": self.linesearch_start,
+            "linesearch_steps": self.linesearch_steps,
+            "points": self.points.to_dict(),
+            "points_needed": self.points_needed,
+            "final_step": self.final_step.tolist(),
+            "final_distance": self.final_distance,
+            "minimized": self.minimized,
+            "direction": self.direction.tolist(),
+            "linesearch_history": self.linesearch_history.to_dict(),
+            "active_point": self.active_point
+        }
+
+    @classmethod
+    def from_dict(cls, d, molsys, history, params):
+        
+        linesearch = cls(molsys, history, params)
+        linesearch.linesearch_max_iter = d["linesearch_max_iter"]
+        linesearch.linesearch_start = d["linesearch_start"]
+        linesearch.linesearch_steps = d["linesearch_steps"]
+        linesearch.points = d["points"]
+        linesearch.final_step = np.asarray(d["final_step"])
+        linesearch.final_distance = d["final_distance"]
+        linesearch.minimized = d["minimized"]
+        linesearch.direction = np.asarray(d["direction"])
+        linesearch.linesearch_history = History.from_dict(d["linesearch_history"])
+        linesearch.active_point = d["active_point"]
+        return linesearch
+
     def fit(self):
         """Determines where the next step should head. Remove points from self.points as needed
         Add the new points. Must set self.final_point if the linesearch has finished.

--- a/optking/opt_helper.py
+++ b/optking/opt_helper.py
@@ -1,7 +1,6 @@
 """
-Helpers to provide high-level interfaces for optking.  In particular to be able
-to input one's own gradients and run 1 step at a time.
-
+Helpers to provide high-level interfaces for optking.  The Helpers allow individual steps to be taken easily. 
+EngineHelper runs calculations through QCEngine. CustomHelper adds the abilility to directly input gradients.
 """
 
 import logging

--- a/optking/opt_helper.py
+++ b/optking/opt_helper.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import Union
 
 import numpy as np
+from optking.IRCfollowing import IntrinsicReactionCoordinate
 import qcelemental as qcel
 
 from . import compute_wrappers, hessian, history, molsys, optwrapper
@@ -92,7 +93,11 @@ class Helper(ABC):
                 string += self.opt_manager.opt_method.irc_history.progress_report(return_str=True)
         elif "FAILED" not in status and len(energies) > 0:
             if self.params.opt_type == 'IRC':
-                conv_info["sub_step_num"] = self.opt_manager.opt_method.sub_step_number
+                irc_object: IntrinsicReactionCoordinate = self.opt_manager.opt_method
+                conv_info["sub_step_num"] = irc_object.sub_step_number
+                conv_info["iternum"] = irc_object.irc_step_number
+                conv_info["fq"] = irc_object.irc_history._project_forces(self.fq, self.molsys)
+
             string += conv_check(conv_info, self.params.__dict__, str_mode="table")
 
         string += "Next Geometry in Ang \n"

--- a/optking/opt_helper.py
+++ b/optking/opt_helper.py
@@ -91,6 +91,8 @@ class Helper(ABC):
             else:
                 string += self.opt_manager.opt_method.irc_history.progress_report(return_str=True)
         elif "FAILED" not in status and len(energies) > 0:
+            if self.params.opt_type == 'IRC':
+                conv_info["sub_step_num"] = self.opt_manager.opt_method.sub_step_number
             string += conv_check(conv_info, self.params.__dict__, str_mode="table")
 
         string += "Next Geometry in Ang \n"

--- a/optking/optimize.py
+++ b/optking/optimize.py
@@ -624,8 +624,9 @@ def prepare_opt_output(o_molsys, computer, rxnpath=False, error=None):
         qc_output.update({"success": False, "error": {"error_type": error.err_type, "error_message": error.mesg}})
 
     if rxnpath:
+        print(rxnpath)
         qc_output["extras"]["irc_rxn_path"] = rxnpath
-        qc_output["final_geometry"] = rxnpath[-2]["Energy"]
-        qc_output["extras"]["final_irc_energy"] = rxnpath[-2]["Geometry"]
+        qc_output["final_geometry"] = rxnpath[-2]["x"]
+        qc_output["extras"]["final_irc_energy"] = rxnpath[-2]["energy"]
 
     return qc_output

--- a/optking/tests/test_irc_hooh.py
+++ b/optking/tests/test_irc_hooh.py
@@ -39,8 +39,8 @@ def test_hooh_irc(check_iter):
     for step in IRC:
         print(
             "%15d%15.5f%20.10f%15.5f"
-            % (step["Step Number"], step["Arc Distance"], step["Energy"], step["Intco Values"][5])
+            % (step["step_number"], step["arc_dist"], step["energy"], step["q"][5])
         )
 
-    assert psi4.compare_values(energy_5th_IRC_pt, IRC[5]["Energy"], 6, "Energy of 5th IRC point.")  # TEST
+    assert psi4.compare_values(energy_5th_IRC_pt, IRC[5]["energy"], 6, "Energy of 5th IRC point.")  # TEST
     utils.compare_iterations(json_output, 45, check_iter)

--- a/optking/tests/test_opthelper.py
+++ b/optking/tests/test_opthelper.py
@@ -140,7 +140,9 @@ def test_stepwise_export():
         opt.gX = grad.np.reshape(-1)
         opt.E = wfn.energy()
         opt.compute()
+        print(opt.pre_step_str())
         opt.take_step()
+        print(opt.post_step_str())
         conv = opt.test_convergence()
         if conv is True:
             print("Optimization SUCCESS:")
@@ -212,7 +214,9 @@ def test_hooh_irc(check_iter):
         opt.gX = grad.np.reshape(-1)
         opt.E = wfn.energy()
         opt.compute()
+        print(opt.pre_step_str())
         opt.take_step()
+        print(opt.post_step_str())
         conv = opt.test_convergence()
         if conv is True:
             print("Optimization SUCCESS:")
@@ -232,7 +236,6 @@ def test_hooh_irc(check_iter):
 
     assert psi4.compare_values(energy_5th_IRC_pt, IRC[5]["energy"], 6, "Energy of 5th IRC point.")  # TEST
     utils.compare_iterations(json_output, 45, check_iter)
-
 
 def test_linesearch(check_iter):
     import psi4
@@ -269,7 +272,9 @@ def test_linesearch(check_iter):
         opt.gX = grad.np.reshape(-1)
         opt.E = wfn.energy()
         opt.compute()
+        print(opt.pre_step_str())
         opt.take_step()
+        print(opt.post_step_str())
         conv = opt.test_convergence()
         if conv is True:
             print("Optimization SUCCESS:")

--- a/optking/tests/test_opthelper.py
+++ b/optking/tests/test_opthelper.py
@@ -203,7 +203,6 @@ def test_hooh_irc(check_iter):
 
     for i in range(50):
         opt = optking.CustomHelper.from_dict(optSaved)
-        print(opt.step_num)
 
         if i == 0:
             H = psi4.hessian("hf")
@@ -212,10 +211,8 @@ def test_hooh_irc(check_iter):
         grad, wfn = psi4.gradient("hf", return_wfn=True)
         opt.gX = grad.np.reshape(-1)
         opt.E = wfn.energy()
-        print(opt.pre_step_str())
         opt.compute()
         opt.take_step()
-        print(opt.post_step_str())
         conv = opt.test_convergence()
         if conv is True:
             print("Optimization SUCCESS:")
@@ -235,3 +232,63 @@ def test_hooh_irc(check_iter):
 
     assert psi4.compare_values(energy_5th_IRC_pt, IRC[5]["energy"], 6, "Energy of 5th IRC point.")  # TEST
     utils.compare_iterations(json_output, 45, check_iter)
+
+
+def test_linesearch(check_iter):
+    import psi4
+    from .utils import utils
+    
+    refenergy = -1053.880393  # Eh
+    Ar2 = psi4.geometry(
+        """
+      Ar
+      Ar 1 5.0
+    """
+    )
+
+    psi4.core.clean_options()
+    psi4_options = {
+        "basis": "cc-pvdz",
+        "d_convergence": 10
+    }
+
+    optking_options = {
+        "geom_maxiter": 60,
+        "g_convergence": "gau_tight",
+        "step_type": "SD",
+    }
+
+    psi4.set_options(psi4_options)
+    opt = optking.CustomHelper(Ar2, optking_options)
+    optSaved = opt.to_dict()
+
+    for _ in range(50):
+        opt = optking.CustomHelper.from_dict(optSaved)
+
+        grad, wfn = psi4.gradient("mp2", return_wfn=True)
+        opt.gX = grad.np.reshape(-1)
+        opt.E = wfn.energy()
+        opt.compute()
+        opt.take_step()
+        conv = opt.test_convergence()
+        if conv is True:
+            print("Optimization SUCCESS:")
+            break
+        else:
+            optSaved = opt.to_dict()
+        geom = psi4.core.Matrix.from_array(opt.molsys.geom)
+        Ar2.set_geometry(geom)
+        Ar2.update_geometry()
+
+    else:
+        print("Optimization FAILURE:\n")
+
+    psi4.set_options(psi4_options)
+
+    # "linesearch" is not currrently recognized by psi4 read_options.
+    json_output = opt.close()
+    E = json_output["energies"][-1]
+    nucenergy = json_output["trajectory"][-1]["properties"]["nuclear_repulsion_energy"]
+    assert psi4.compare_values(nucenergy, nucenergy, 3, "Nuclear repulsion energy")  # TEST
+    assert psi4.compare_values(refenergy, E, 1, "Reference energy")  # TEST
+    utils.compare_iterations(json_output, 25, check_iter)

--- a/optking/tests/test_opthelper.py
+++ b/optking/tests/test_opthelper.py
@@ -165,3 +165,75 @@ def test_stepwise_export():
     refenergy = -74.9659011923  # TEST
     assert psi4.compare_values(refnucenergy, nucenergy, 3, "Nuclear repulsion energy")
     assert psi4.compare_values(refenergy, E, 6, "Reference energy")
+
+
+def test_hooh_irc(check_iter):
+    import psi4
+    import pprint
+    energy_5th_IRC_pt = -150.812913276783  # TEST
+    h2o2 = psi4.geometry(
+        """
+      H     0.0000000000   0.9803530335  -0.8498671785
+      O     0.0000000000   0.6988545188   0.0536419016
+      O     0.0000000000  -0.6988545188   0.0536419016
+      H     0.0000000000  -0.9803530335  -0.8498671785
+    """
+    )
+    # Necessary since IRC will break C2h.
+    h2o2.reset_point_group("c2")
+
+    psi4.core.clean_options()
+
+    psi4_options = {
+        "basis": "dzp",
+        "scf_type": "pk",
+    }
+
+    params = {
+        "g_convergence": "gau_verytight",
+        "opt_type": "irc",
+        "geom_maxiter": 60,
+        "full_hess_every": 0
+    }
+
+    psi4.set_options(psi4_options)
+    opt = optking.CustomHelper(h2o2, params)
+    optSaved = opt.to_dict()
+    
+    pp = pprint.PrettyPrinter(indent=2)
+
+    for i in range(3):
+        opt = optking.CustomHelper.from_dict(optSaved)
+        print(opt.step_num)
+
+        if i == 0:
+            H = psi4.hessian("hf")
+            opt.HX = H.np
+
+        grad, wfn = psi4.gradient("hf", return_wfn=True)
+        opt.gX = grad.np.reshape(-1)
+        opt.E = wfn.energy()
+        print(opt.pre_step_str())
+        opt.compute()
+        opt.take_step()
+        print(opt.post_step_str())
+        conv = opt.test_convergence()
+        if conv is True:
+            print("Optimization SUCCESS:")
+            break
+        else:
+            optSaved = opt.to_dict()
+            print("IRC step number")
+            pp.pprint(optSaved)
+        geom = psi4.core.Matrix.from_array(opt.molsys.geom)
+        h2o2.set_geometry(geom)
+        h2o2.update_geometry()
+
+    else:
+        print("Optimization FAILURE:\n")
+
+    # print(opt.history.summary_string())
+    json_output = opt.close()
+
+    E = json_output["energies"][-1]  # TEST
+    assert False


### PR DESCRIPTION
- [x] Fix printing issue for IRCs in CustomHelper
- [x] Standardize serialization of classes to dict for restarting
- [x] Fix serialization of IRCs (iterations not tracked correctly)
- [x] Add CustomHelper tests for IRCS and Linesearch
- [x] Requesting `irc_points = 1` now quits immediately after converging 1 point
   The previous behavior would add the TS as the zeroth point and quit. The immediate quit means that the wfn and energy
   match the final point when run in the psi4 driver as well.
- [x] Additional IRC convergence check. To prevent stepping over the minimum a negative overlap and energy increase
   terminates the IRC. This is in addition to an overlap of less than -0.7. Fixes 1 IRC test in psi4 where two points with higher energy
   beyond the minimum are optimized. 