### PR TITLE
Adds interfrag_tight to g_convergence option

### DIFF
--- a/optking/convcheck.py
+++ b/optking/convcheck.py
@@ -160,7 +160,7 @@ def _test_for_convergence(conv_met, conv_active, return_str=False):
 
     if op.Params.i_untampered:
         # flexible_criteria forces this route, but with an adjusted value for an individual criteria
-        if "GAU" in op.Params.g_convergence:
+        if "GAU" in op.Params.g_convergence or op.Params.g_convergence == "INTERFRAG_TIGHT":
             conv_requirements = CONVERGENCE_PRESETS.get("GAUSSIAN")
         elif op.Params.g_convergence in ["QCHEM", "MOLPRO"]:
             conv_requirements = CONVERGENCE_PRESETS.get("QCHEM_MOLPRO")

--- a/optking/optparams.py
+++ b/optking/optparams.py
@@ -47,6 +47,7 @@ allowedStringOptions = {
         "TURBOMOLE",
         "CFOUR",
         "NWCHEM_LOOSE",
+        "INTERFRAG_TIGHT",
     ),
     "hess_update": ("NONE", "BFGS", "MS", "POWELL", "BOFILL"),
     "intrafrag_hess": ("SCHLEGEL", "FISCHER", "SCHLEGEL", "SIMPLE", "LINDH", "LINDH_SIMPLE"),
@@ -544,6 +545,20 @@ class OptParams(object):
             self.i_max_disp = True
             self.conv_rms_disp = 3.6e-3
             self.i_rms_disp = True
+        elif self.g_convergence == "INTERFRAG_TIGHT":
+            self.i_untampered = True
+            self.conv_max_DE = 1.0e-5
+            self.i_max_DE = True
+            self.conv_max_force = 1.5e-5
+            self.i_max_force = True
+            self.conv_rms_force = 1.0e-5
+            self.i_rms_force = True
+            self.conv_max_disp = 6.0e-4
+            self.i_max_disp = True
+            self.conv_rms_disp = 4.0e-4
+            self.i_rms_disp = True
+
+
 
         # ---  Specific optimization criteria
         if "MAX_FORCE_G_CONVERGENCE" in uod:

--- a/optking/tests/test_dimers_h2o.py
+++ b/optking/tests/test_dimers_h2o.py
@@ -68,7 +68,8 @@ MP2minEnergy = -152.5352095
 
 
 @pytest.mark.dimers
-def test_dimers_h2o_auto(check_iter):  # auto reference pt. creation
+@pytest.mark.parametrize("option, iter", [("gau_tight", 13), ("interfrag_tight", 11)])
+def test_dimers_h2o_auto(check_iter, option, iter):  # auto reference pt. creation
     h2oD = psi4.geometry(
         """
       0 1
@@ -90,7 +91,7 @@ def test_dimers_h2o_auto(check_iter):  # auto reference pt. creation
         "basis": "aug-cc-pvdz",
         "geom_maxiter": 40,
         "frag_mode": "MULTI",
-        "g_convergence": "gau_tight",
+        "g_convergence": f"{option}",
     }
     psi4.set_options(psi4_options)
 
@@ -100,4 +101,4 @@ def test_dimers_h2o_auto(check_iter):  # auto reference pt. creation
     E = json_output["energies"][-1]
     assert psi4.compare_values(MP2minEnergy, E, 6, "MP2 Energy opt from afar, auto")
 
-    utils.compare_iterations(json_output, 13, check_iter)
+    utils.compare_iterations(json_output, iter, check_iter)


### PR DESCRIPTION
- [x] Add `interfrag_tight` convergence keyword from optking 2.0. Comparable to GAU_TIGHT but with looser `max_disp` and `rms_disp` thresholds.