### PR TITLE
Tightened up exclusion of redundant coordinate space.

### DIFF
--- a/optking/displace.py
+++ b/optking/displace.py
@@ -56,10 +56,10 @@ def displace_molsys(molsys, dq_in, fq=None, ensure_convergence=False, return_str
                 tentative = q_in[start + i] + dq_in[start + i]
                 if tentative > I.range_max:
                     dq_in[start + i] = I.range_max - q_in[start + i]
-                    logger.info("setting to max: {:10.5f}".format(dq_in[start + i]))
+                    logger.info("\tSetting to max: {:12.7f}".format(dq_in[start + i]))
                 elif tentative < I.range_min:
                     dq_in[start + i] = I.range_min - q_in[start + i]
-                    logger.info("setting to min: {:10.5f}".format(dq_in[start + i]))
+                    logger.info("\tSetting to min: {:12.7f}".format(dq_in[start + i]))
                 else:
                     pass  # value within range
 
@@ -338,7 +338,7 @@ def back_transformation(
     while bt_iter_continue:
 
         # dq_rms = rms(dq)
-        dx_rms, dx_max = dq_to_dx(intcos, geom, dq, print_lvl > 2, op.Params.bt_pinv_rcond)
+        dx_rms, dx_max = dq_to_dx(intcos, geom, dq, print_lvl > 2)
 
         # Met convergence thresholds
         if dx_rms < bt_dx_conv and dx_max < bt_dx_conv:
@@ -395,7 +395,7 @@ def back_transformation(
 # B (dx) = B * [Bt (B Bt)^-1 dq]
 #   dx = Bt (B Bt)^-1 dq
 #   dx = Bt G^-1 dq, where G = B B^t.
-def dq_to_dx(intcos, geom, dq, printDetails, pinv_rcond):
+def dq_to_dx(intcos, geom, dq, printDetails):
     """Convert dq to dx.  Geometry is updated
 
     Parameters
@@ -414,10 +414,8 @@ def dq_to_dx(intcos, geom, dq, printDetails, pinv_rcond):
     """
     B = intcosMisc.Bmat(intcos, geom)
     G = B @ B.T
-    Ginv = np.linalg.pinv(G, rcond=pinv_rcond)
+    Ginv = symm_mat_inv(G, redundant=True, smallValLimit = op.Params.bt_pinv_rcond)
     dx = B.T @ Ginv @ dq
-    # large values in Ginv indicate rcond needs adjusted
-    # logger.debug("Ginv matrix:\n" + print_mat_string(Ginv))
 
     if printDetails:
         qOld = intcosMisc.q_values(intcos, geom)

--- a/optking/molsys.py
+++ b/optking/molsys.py
@@ -828,7 +828,7 @@ class Molsys(object):
         Nint = self.num_intcos
         # compute projection matrix = G G^-1
         G = self.Gmat()
-        G_inv = symm_mat_inv(G, redundant=True)
+        G_inv = symm_mat_inv(G, redundant=True, smallValLimit=op.Params.bt_pinv_rcond)
         Pprime = G @ G_inv
         # Add constraints to projection matrix
         # fq is passed to Supplement matrix with ranged variables that are at their limit
@@ -837,7 +837,7 @@ class Molsys(object):
         if C is not None:
             logger.debug("Adding constraints for projection.\n" + print_mat_string(C))
             CPC = C @ Pprime @ C
-            CPCInv = symm_mat_inv(CPC, redundant=True)
+            CPCInv = symm_mat_inv(CPC, redundant=True, smallValLimit=op.Params.bt_pinv_rcond)
             P = Pprime - Pprime @ C @ CPCInv @ C @ Pprime
         else:
             P = Pprime

--- a/optking/optparams.py
+++ b/optking/optparams.py
@@ -286,7 +286,10 @@ class OptParams(object):
         self.bt_max_iter = uod.get("bt_max_iter", 25)
         self.bt_dx_conv = uod.get("bt_dx_conv", 1.0e-7)
         self.bt_dx_rms_change_conv = uod.get("bt_dx_rms_change_conv", 1.0e-12)
-        self.bt_pinv_rcond = uod.get("bt_pinv_rcond", 1.0e-7)
+        # The following should be used whenever redundancies in the coordinates
+        # are removed, in particular when forces and Hessian are projected and
+        # in back-transformation from delta(q) to delta(x).
+        self.bt_pinv_rcond = uod.get("bt_pinv_rcond", 1.0e-6)
         #
         # For multi-fragment molecules, treat as single bonded molecule or via interfragment
         # coordinates. A primary difference is that in ``MULTI`` mode, the interfragment
@@ -456,7 +459,7 @@ class OptParams(object):
 
         # Threshold for which entries in diagonalized redundant matrix are kept and
         # inverted while computing a generalized inverse of a matrix
-        self.redundant_eval_tol = 1.0e-10
+        self.redundant_eval_tol = 1.0e-10 # to be deprecated.
         #
         # --- SET INTERNAL OPTIMIZATION PARAMETERS ---
         self.i_max_force = False

--- a/optking/stepAlgorithms.py
+++ b/optking/stepAlgorithms.py
@@ -721,14 +721,16 @@ class RestrictedStepRFO(RFO):
 
         # scale RFO matrix leaving the last row unchanged, compute eigenvectors
         SRFOmat[:-1, :-1] = RFOmat[:-1, :-1] / alpha
-        SRFOmat[-1, :-1] = RFOmat[-1, :-1] / alpha**0.5
-        SRFOmat[:-1, -1] = RFOmat[:-1, -1] / alpha**0.5
+        # in case alpha goes negative, this prevents warnings
+        rootAlpha = np.sign(alpha) * (np.abs(alpha))**0.5
+        SRFOmat[-1, :-1] = RFOmat[-1, :-1] / rootAlpha
+        SRFOmat[:-1, -1] = RFOmat[:-1, -1] / rootAlpha
         SRFOevals, SRFOevects = symm_mat_eig(SRFOmat)
 
         SRFOevects = self._intermediate_normalize(SRFOevects)
 
         # transform step back.
-        scale_mat = np.diag(np.repeat(1 / alpha**0.5, dim1))
+        scale_mat = np.diag(np.repeat(1 / rootAlpha, dim1))
         scale_mat[-1, -1] = 1
         # SRFOevects = np.einsum("ij, jk -> ik", scale_mat, SRFOevects)
         SRFOevects = np.transpose(scale_mat @ np.transpose(SRFOevects))

--- a/optking/tests/test_ccsd_g_opt.py
+++ b/optking/tests/test_ccsd_g_opt.py
@@ -142,19 +142,13 @@ def test_uccsdpt_ch2(check_iter):
 
     result = optking.optimize_psi4("CCSD(T)")
 
-    this_scf = result["trajectory"][-1]["properties"]["scf_total_energy"]  # TEST
     this_ccsd_t = result["trajectory"][-1]["properties"]["ccsd_prt_pr_correlation_energy"]  # TEST
     this_total = result["trajectory"][-1]["properties"]["ccsd_prt_pr_total_energy"]  # TEST
-    this_return = result["trajectory"][-1]["properties"]["return_energy"]  # TEST
-    REF_scf = -38.9265520844  # TEST
+    REF_scf = -38.9265520844  # TEST. Value is not currently included in trajectory output
     REF_ccsd_t = -0.1171601876  # TEST
     REF_total = -39.0437122710  # TEST
-    # print( '{:15.10f}'.format(this_scf))
-    # print( '{:15.10f}'.format(this_ccsd_t))
-    # print( '{:15.10f}'.format(this_total))
-    assert psi4.compare_values(REF_scf, this_scf, 6, "SCF energy")  # TEST
     assert psi4.compare_values(REF_ccsd_t, this_ccsd_t, 6, "CCSD(T) contribution")  # TEST
     assert psi4.compare_values(REF_total, this_total, 6, "Total CCSD(T) energy")  # TEST
-    assert psi4.compare_values(REF_total, this_return, 6, "Total CCSD(T) return energy")  # TEST
 
     utils.compare_iterations(result, 9, check_iter)
+


### PR DESCRIPTION
`bt_pinv_rcond` now used in both projection of forces, hessian, and in calculating step.
And default value increased to 10^-6.
Also, cleanup of various tests.