### PR TITLE
use qcng task_config inquiry

### DIFF
--- a/optking/compute_wrappers.py
+++ b/optking/compute_wrappers.py
@@ -22,12 +22,13 @@ class ComputeWrapper:
 
     """
 
-    def __init__(self, molecule, model, keywords, program):
+    def __init__(self, molecule, model, keywords, program, config=None):
 
         self.molecule = molecule
         self.model = model
         self.keywords = keywords
         self.program = program
+        self.config = config if config else {}
         self.trajectory = []
         self.energies = []
 
@@ -151,12 +152,12 @@ class QCEngineComputer(ComputeWrapper):
 
         inp = self.generate_schema_input(driver)
 
-        local_options = {}
-        if self.program == "psi4":
-            import psi4
+        local_options = self.config #{}
+        #if self.program == "psi4":
+        #    import psi4
 
-            local_options["memory"] = psi4.core.get_memory() / 1000000000
-            local_options["ncores"] = psi4.core.get_num_threads()
+        #    local_options["memory"] = psi4.core.get_memory() / 1000000000
+        #    local_options["ncores"] = psi4.core.get_num_threads()
 
         ret = qcengine.compute(inp, self.program, True, local_options)
         return ret

--- a/optking/optwrapper.py
+++ b/optking/optwrapper.py
@@ -204,12 +204,13 @@ def make_computer(opt_input: dict, computer_type):
     qc_input = opt_input["input_specification"]
     options = qc_input["keywords"]
     model = qc_input["model"]
+    config = opt_input["input_specification"]["extras"]["_qcengine_local_config"]
 
     if computer_type == "psi4":
         # Please note that program is not actually used here
         return Psi4Computer(molecule, model, options, program)
     elif computer_type == "qc":
-        return QCEngineComputer(molecule, model, options, program)
+        return QCEngineComputer(molecule, model, options, program, config)
     elif computer_type == "user":
         logger.info("Creating a UserComputer")
         return UserComputer(molecule, model, options, program)


### PR DESCRIPTION
This isn't a ready-to-merge PR; it's more of a discussion opener. https://github.com/MolSSI/QCEngine/issues/402 pointed out that qcengine-driven optimizations aren't obeying the task_config (formerly local_options) ncores/memory/scratch/etc. user settings passed into `qcng.compute_procedure()` for user control. He has a little script showing the cores psi4 (the common gradient-generator) is getting, and optking is always giving psi4 single-thread, which I can see is deliberately set by optking to `psi4.get_num_threads()`.

I know that all the ways and means of commencing and routing among psi4/other-gradient-generators/optking/qcengine are complex, and the current setup probably was designed to play nicely with psi4 as top-level in some way. So I wonder if design considerations rule out this PR's suggestion or if there's a way to make it work.

No hurry on this -- just lodging the issue in the right place.