### PR TITLE
fix build for py312

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: 3.9
           - conda-env: base
             python-version: "3.10"
+          - conda-env: base
+            python-version: "3.12"
     env:
       PYVER: ${{ matrix.cfg.python-version }}
       CONDA_ENV: ${{ matrix.cfg.conda-env }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         cfg:
           - conda-env: base

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -12,6 +12,6 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-  - psi4
+  - psi4 1.9.1
   - dftd3-python
   - codecov

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -1,7 +1,7 @@
 name: test
 channels:
-  - defaults
   - conda-forge
+  - nodefaults
 dependencies:
     # Base
   - numpy
@@ -13,6 +13,5 @@ dependencies:
   - pytest
   - pytest-cov
   - psi4
-  - simple-dftd3
   - dftd3-python
   - codecov

--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -1,7 +1,7 @@
 name: test
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
     # Base
   - numpy
@@ -14,7 +14,6 @@ dependencies:
   - pytest
   - pytest-cov
   - psi4
-  - simple-dftd3
   - dftd3-python
   - codecov
 

--- a/devtools/conda-envs/dev.yaml
+++ b/devtools/conda-envs/dev.yaml
@@ -13,7 +13,7 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-  - psi4
+  - psi4 1.9.1
   - dftd3-python
   - codecov
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -343,9 +343,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
includes much of #89 

should produce the below which I'll fix next commit.
```
Obtaining file:///psi/gits/optking
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      /psi/gits/optking/versioneer.py:432: SyntaxWarning: invalid escape sequence '\s'
        ] = '''
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/psi/gits/optking/setup.py", line 20, in <module>
          version=versioneer.get_version(),
                  ^^^^^^^^^^^^^^^^^^^^^^^^
        File "/psi/gits/optking/versioneer.py", line 1524, in get_version
          return get_versions()["version"]
                 ^^^^^^^^^^^^^^
        File "/psi/gits/optking/versioneer.py", line 1451, in get_versions
          cfg = get_config_from_root(root)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/psi/gits/optking/versioneer.py", line 346, in get_config_from_root
          parser = configparser.SafeConfigParser()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
      [end of output]
 ```