### PR TITLE
Image rfo

### DIFF
--- a/optking/IRCfollowing.py
+++ b/optking/IRCfollowing.py
@@ -95,7 +95,14 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
 
             self.history.append(self.molsys.geom, energy, fq, self.molsys.gradient_to_cartesians(-1 * fq))
             dq = self.dq_irc(fq, H)
-            dq, dx, return_str = displace_molsys(self.molsys, dq, fq, ensure_convergence=True, return_str=True)
+            dq, dx, return_str = displace_molsys(
+                self.molsys,
+                dq,
+                fq,
+                ensure_convergence=True,
+                return_str=True,
+                print_lvl=self.params.print_lvl
+            )
             logger.info("IRC Constrained step calculation finished.")
 
             # Complete history entry of step.
@@ -178,7 +185,12 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
 
         # revisit
         dq1, dx1, return_str1 = displace_molsys(
-            self.molsys, dq_pivot, fq, ensure_convergence=True, return_str=return_str
+            self.molsys,
+            dq_pivot,
+            fq,
+            ensure_convergence=True,
+            return_str=return_str,
+            print_lvl=self.params.print_lvl
         )
         x_pivot = self.molsys.geom
         q_pivot = self.molsys.q_array()
@@ -187,10 +199,15 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
         # Step again to get initial guess for next step.  Leave geometry in o_molsys.
         logger.info("Computing Dq to First Guess Point")
         logger.debug(print_array_string(dq_pivot))
-        x_guess = x_pivot.copy()
+        # x_guess = x_pivot.copy() unused
         # displace(o_molsys.intcos, x_guess, dq_pivot, ensure_convergence=True)
         dq2, dx2, return_str2 = displace_molsys(
-            self.molsys, dq_pivot, fq, ensure_convergence=True, return_str=return_str
+            self.molsys,
+            dq_pivot,
+            fq,
+            ensure_convergence=True,
+            return_str=return_str,
+            print_lvl=self.params.print_lvl
         )
         # self.molsys.geom = x_guess
         if return_str:

--- a/optking/IRCfollowing.py
+++ b/optking/IRCfollowing.py
@@ -99,9 +99,9 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
                 self.molsys,
                 dq,
                 fq,
-                ensure_convergence=True,
+                **self.params.__dict__,
                 return_str=True,
-                print_lvl=self.params.print_lvl
+                ensure_convergence=True
             )
             logger.info("IRC Constrained step calculation finished.")
 
@@ -188,9 +188,9 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
             self.molsys,
             dq_pivot,
             fq,
+            **self.params.__dict__,
             ensure_convergence=True,
-            return_str=return_str,
-            print_lvl=self.params.print_lvl
+            return_str=True
         )
         x_pivot = self.molsys.geom
         q_pivot = self.molsys.q_array()
@@ -199,7 +199,7 @@ class IntrinsicReactionCoordinate(OptimizationInterface):
         # Step again to get initial guess for next step.  Leave geometry in o_molsys.
         logger.info("Computing Dq to First Guess Point")
         logger.debug(print_array_string(dq_pivot))
-        # x_guess = x_pivot.copy() unused
+        x_guess = x_pivot.copy()
         # displace(o_molsys.intcos, x_guess, dq_pivot, ensure_convergence=True)
         dq2, dx2, return_str2 = displace_molsys(
             self.molsys,

--- a/optking/bend.py
+++ b/optking/bend.py
@@ -85,11 +85,11 @@ class Bend(Simple):
         return s
 
     def __eq__(self, other):
-        if self.atoms != other.atoms:
-            return False
-        elif not isinstance(other, Bend):
+        if not isinstance(other, Bend):
             return False
         elif self.bend_type != other.bend_type:
+            return False
+        elif self.atoms != other.atoms:
             return False
         else:
             return True

--- a/optking/displace.py
+++ b/optking/displace.py
@@ -162,7 +162,7 @@ def displace_molsys(
 
     linear_list = linear_bend_check(molsys)
     if linear_list:
-        raise AlgError("New linear angles", newLinearBends=linear_list)
+        raise AlgError("New linear angles", new_linear_bends=linear_list)
 
     # RAK TODO : remember why I want to return dx and what to do with it.
     if return_str:

--- a/optking/displace.py
+++ b/optking/displace.py
@@ -200,7 +200,10 @@ def displace_frag(frag, dq_in, **kwargs):
     bool : conv and frozen_conv
     """
 
-    ensure_convergence = kwargs.get("ensure_convergence", False) 
+    ensure_convergence = kwargs.get(
+        "ensure_convergence",
+        kwargs.get("ensure_bt_convergence", False)
+    )
     
     geom = frag.geom
     dq = dq_in.copy()

--- a/optking/displace.py
+++ b/optking/displace.py
@@ -314,6 +314,7 @@ def displace_frag(frag, dq_in, **kwargs):
             **kwargs
             )
 
+        # unsuppress printing for the next stage
         kwargs.update({"print_lvl": kwargs.get("print_lvl", 0) + 1})
         frag.unfix_bend_axes()
 

--- a/optking/displace.py
+++ b/optking/displace.py
@@ -5,6 +5,7 @@ from itertools import compress
 
 from . import intcosMisc
 from .addIntcos import linear_bend_check
+from .molsys import Molsys
 from .exceptions import AlgError, OptError
 from .linearAlgebra import abs_max, rms, symm_mat_inv
 from . import log_name
@@ -24,7 +25,7 @@ logger = logging.getLogger(f"{log_name}{__name__}")
 
 # Displace molecular system
 def displace_molsys(
-        molsys,
+        molsys: Molsys,
         dq_in,
         fq=None,
         **kwargs
@@ -65,12 +66,12 @@ def displace_molsys(
     # Modify dq_in to account for frozen coordinates and ranged coordinates
     # These do not represent desired Delta(q)
     q_in = molsys.q_array()
-    for i, frag in enumerate(molsys.fragments):
+    for f, frag in enumerate(molsys.fragments):
         if frag.frozen:
             # For accounting only, since displace_frag is not called.
-            dq_in[molsys.frag_intco_range(i)] = 0
-            logger.info("\tFragment %d is frozen, so not displacing" % (i + 1))
-        start = molsys.frag_1st_intco(i)
+            dq_in[molsys.frag_intco_range(f)] = 0
+            logger.info("\tFragment %d is frozen, so not displacing" % (f + 1))
+        start = molsys.frag_1st_intco(f)
         for i, intco in enumerate(frag.intcos):
             if intco.frozen:
                 dq_in[start + i] = 0.0
@@ -89,13 +90,13 @@ def displace_molsys(
     q_in = molsys.q_array()  # recompute with limitations above
     q_target = q_in + dq_in
 
-    for i, frag in enumerate(molsys.fragments):
+    for f, frag in enumerate(molsys.fragments):
         if frag.frozen or frag.num_intcos == 0:
             continue
-        logger.info("\tDetermining Cartesian step for fragment %d." % (i + 1))
+        logger.info("\tDetermining Cartesian step for fragment %d." % (f + 1))
         dq_frag, conv = displace_frag(
             frag,
-            dq_in[molsys.frag_intco_slice(i)],
+            dq_in[molsys.frag_intco_slice(f)],
             **kwargs
         )
 
@@ -476,7 +477,7 @@ def dq_to_dx(intcos, geom, dq, **kwargs):
 
     print_details = kwargs.get("print_details", False)
     small_val_limit = kwargs.get("small_val_limit", 1e-6)
-    
+
     B = intcosMisc.Bmat(intcos, geom)
     G = B @ B.T
     Ginv = symm_mat_inv(G, redundant=True, small_val_limit=small_val_limit)

--- a/optking/displace.py
+++ b/optking/displace.py
@@ -159,12 +159,13 @@ def displace_frag(F, dq_in, ensure_convergence=False):
 
     Returns
     -------
-    tuple(np.ndarray, bool) : dq achieved, conv and frozen_conv
+    np.ndarray: dq achieved
+    bool : conv and frozen_conv
     """
     geom = F.geom
     dq = dq_in.copy()
     if not F.num_intcos or not len(geom) or not len(dq_in):
-        return dq and True
+        return dq, True
 
     geom_orig = np.copy(geom)
     q_orig = F.q_array()

--- a/optking/displace.py
+++ b/optking/displace.py
@@ -4,11 +4,9 @@ import numpy as np
 from itertools import compress
 
 from . import intcosMisc
-from . import optparams as op
 from .addIntcos import linear_bend_check
 from .exceptions import AlgError, OptError
 from .linearAlgebra import abs_max, rms, symm_mat_inv
-from .printTools import print_mat_string, print_array_string
 from . import log_name
 
 logger = logging.getLogger(f"{log_name}{__name__}")
@@ -25,7 +23,14 @@ logger = logging.getLogger(f"{log_name}{__name__}")
 
 
 # Displace molecular system
-def displace_molsys(molsys, dq_in, fq=None, ensure_convergence=False, return_str=False):
+def displace_molsys(
+        molsys,
+        dq_in,
+        fq=None,
+        ensure_convergence=False,
+        return_str=False,
+        print_lvl=1
+    ):
     """Manage internal coordinate step for a molecular system
     Parameters
     ----------
@@ -44,22 +49,22 @@ def displace_molsys(molsys, dq_in, fq=None, ensure_convergence=False, return_str
     # Modify dq_in to account for frozen coordinates and ranged coordinates
     # These do not represent desired Delta(q)
     q_in = molsys.q_array()
-    for iF, F in enumerate(molsys.fragments):
-        if F.frozen:
+    for i, frag in enumerate(molsys.fragments):
+        if frag.frozen:
             # For accounting only, since displace_frag is not called.
-            dq_in[molsys.frag_intco_range(iF)] = 0
-            logger.info("\tFragment %d is frozen, so not displacing" % (iF + 1))
-        start = molsys.frag_1st_intco(iF)
-        for i, I in enumerate(F.intcos):
-            if I.frozen:
+            dq_in[molsys.frag_intco_range(i)] = 0
+            logger.info("\tFragment %d is frozen, so not displacing" % (i + 1))
+        start = molsys.frag_1st_intco(i)
+        for i, intco in enumerate(frag.intcos):
+            if intco.frozen:
                 dq_in[start + i] = 0.0
-            elif I.ranged:
+            elif intco.ranged:
                 tentative = q_in[start + i] + dq_in[start + i]
-                if tentative > I.range_max:
-                    dq_in[start + i] = I.range_max - q_in[start + i]
+                if tentative > intco.range_max:
+                    dq_in[start + i] = intco.range_max - q_in[start + i]
                     logger.info("\tSetting to max: {:12.7f}".format(dq_in[start + i]))
-                elif tentative < I.range_min:
-                    dq_in[start + i] = I.range_min - q_in[start + i]
+                elif tentative < intco.range_min:
+                    dq_in[start + i] = intco.range_min - q_in[start + i]
                     logger.info("\tSetting to min: {:12.7f}".format(dq_in[start + i]))
                 else:
                     pass  # value within range
@@ -68,18 +73,23 @@ def displace_molsys(molsys, dq_in, fq=None, ensure_convergence=False, return_str
     q_in = molsys.q_array()  # recompute with limitations above
     q_target = q_in + dq_in
 
-    for iF, F in enumerate(molsys.fragments):
-        if F.frozen or F.num_intcos == 0:
+    for i, frag in enumerate(molsys.fragments):
+        if frag.frozen or frag.num_intcos == 0:
             continue
-        logger.info("\tDetermining Cartesian step for fragment %d." % (iF + 1))
-        dq_frag, conv = displace_frag(F, dq_in[molsys.frag_intco_slice(iF)], ensure_convergence)
+        logger.info("\tDetermining Cartesian step for fragment %d." % (i + 1))
+        dq_frag, conv = displace_frag(
+            frag,
+            dq_in[molsys.frag_intco_slice(i)],
+            ensure_convergence,
+            print_lvl=1
+        )
 
     for i, DI in enumerate(molsys.dimer_intcos):
         logger.info("\tTaking step for dimer coordinates of fragments %d and %d." % (DI.A_idx + 1, DI.B_idx + 1))
 
-        Axyz = molsys.frag_geom(DI.A_idx)
-        Bxyz = molsys.frag_geom(DI.B_idx)
-        Bxyz[:] = DI.orient_fragment(Axyz, Bxyz, q_target[molsys.dimerfrag_intco_slice(i)])
+        axyz = molsys.frag_geom(DI.A_idx)
+        bxyz = molsys.frag_geom(DI.B_idx)
+        bxyz[:] = DI.orient_fragment(axyz, bxyz, q_target[molsys.dimerfrag_intco_slice(i)])
 
     geom_final = molsys.geom
     # Analyze relative to original input geometry
@@ -146,7 +156,7 @@ def displace_molsys(molsys, dq_in, fq=None, ensure_convergence=False, return_str
         return dq, dx
 
 
-def displace_frag(F, dq_in, ensure_convergence=False):
+def displace_frag(frag, dq_in, ensure_convergence=False, print_lvl=1, opt_type="MIN"):
     """Converts internal coordinate step into the new cartesian geometry
     Parameters
     ----------
@@ -162,13 +172,13 @@ def displace_frag(F, dq_in, ensure_convergence=False):
     np.ndarray: dq achieved
     bool : conv and frozen_conv
     """
-    geom = F.geom
+    geom = frag.geom
     dq = dq_in.copy()
-    if not F.num_intcos or not len(geom) or not len(dq_in):
+    if not frag.num_intcos or not len(geom) or not len(dq_in):
         return dq, True
 
     geom_orig = np.copy(geom)
-    q_orig = F.q_array()
+    q_orig = frag.q_array()
 
     best_geom = np.zeros(geom_orig.shape)
     conv = False  # is back-transformation converged?
@@ -182,10 +192,10 @@ def displace_frag(F, dq_in, ensure_convergence=False):
                 logger.info("\tReducing step-size by a factor of %d." % (2 * cnt))
                 dq[:] = dq_in / (2.0 * cnt)
 
-            F.fix_bend_axes()
-            F.update_dihedral_orientations()
-            conv = back_transformation(F.intcos, geom, dq, op.Params.print_lvl)
-            F.unfix_bend_axes()
+            frag.fix_bend_axes()
+            frag.update_dihedral_orientations()
+            conv = back_transformation(frag.intcos, geom, dq, print_lvl)
+            frag.unfix_bend_axes()
 
             if not conv:
                 if cnt == 5:
@@ -206,9 +216,9 @@ def displace_frag(F, dq_in, ensure_convergence=False):
 
                 best_geom[:] = geom
 
-                F.fix_bend_axes()
-                conv = back_transformation(F.intcos, geom, dq, op.Params.print_lvl)
-                F.unfix_bend_axes()
+                frag.fix_bend_axes()
+                conv = back_transformation(frag.intcos, geom, dq, print_lvl)
+                frag.unfix_bend_axes()
 
                 if not conv:
                     logger.warning("\tCouldn't converge this mini-step; quitting with previous geometry.\n")
@@ -216,41 +226,41 @@ def displace_frag(F, dq_in, ensure_convergence=False):
                     break
 
     else:  # try to back-transform, but continue even if desired dq is not achieved
-        F.fix_bend_axes()
-        F.update_dihedral_orientations()
-        conv = back_transformation(F.intcos, geom, dq, op.Params.print_lvl)
-        F.unfix_bend_axes()
+        frag.fix_bend_axes()
+        frag.update_dihedral_orientations()
+        conv = back_transformation(frag.intcos, geom, dq, print_lvl)
+        frag.unfix_bend_axes()
 
-        if op.Params.opt_type == "IRC" and not conv:
+        if opt_type == "IRC" and not conv:
             raise OptError("Could not take constrained step in an IRC computation.")
 
     # Fix drift/error in any frozen coordinates
     frozen_conv = True
-    if any(intco.frozen for intco in F.intcos) or any(intco.ranged for intco in F.intcos):
+    if any(intco.frozen for intco in frag.intcos) or any(intco.ranged for intco in frag.intcos):
 
-        F.update_dihedral_orientations()
-        F.fix_bend_axes()
-        qnow = intcosMisc.q_values(F.intcos, geom)
-        dq_adjust_frozen = np.zeros(len(F.intcos))
+        frag.update_dihedral_orientations()
+        frag.fix_bend_axes()
+        qnow = intcosMisc.q_values(frag.intcos, geom)
+        dq_adjust_frozen = np.zeros(len(frag.intcos))
 
-        intcosToConstrainBoolean = [0 for i in range(F.num_intcos)]
-        for i, intco in enumerate(F.intcos):
+        constrained_coord_selector = [0] * frag.num_intcos
+        for i, intco in enumerate(frag.intcos):
             if intco.frozen:  # cleanup step = -Dq
                 dq_adjust_frozen[i] = q_orig[i] - qnow[i]
-                intcosToConstrainBoolean[i] = 1
+                constrained_coord_selector[i] = 1
             elif intco.ranged:  # put within range
                 if qnow[i] > intco.range_max:
                     dq_adjust_frozen[i] = intco.range_max - qnow[i]
-                    intcosToConstrainBoolean[i] = 1
+                    constrained_coord_selector[i] = 1
                 elif qnow[i] < intco.range_min:
                     dq_adjust_frozen[i] = intco.range_min - qnow[i]
-                    intcosToConstrainBoolean[i] = 1
+                    constrained_coord_selector[i] = 1
 
         # Could be streamlined with above, but for now testing to see if helps
-        intcosToConstrain = list(compress(F.intcos, intcosToConstrainBoolean))
-        dqToConstrain = np.asarray(list(compress(dq_adjust_frozen, intcosToConstrainBoolean)))
+        constrained_intcos = list(compress(frag.intcos, constrained_coord_selector))
+        constrained_dq = np.asarray(list(compress(dq_adjust_frozen, constrained_coord_selector)))
         adjust_info = "\nAdjustments to Frozen/Ranged Coordinates Needed:\n"
-        for l,v in zip([str(i) for i in intcosToConstrain], dqToConstrain):
+        for l,v in zip([str(i) for i in constrained_intcos], constrained_dq):
             adjust_info += f'{l:>8s}{v:10.6f}\n'
         logger.info(adjust_info)
 
@@ -263,16 +273,16 @@ def displace_frag(F, dq_in, ensure_convergence=False):
         frozen_msg = "\tAdditional back-transformation to adjust frozen/ranged coordinates: "
 
         frozen_conv = back_transformation(
-            intcosToConstrain, #F.intcos,
+            constrained_intcos, #F.intcos,
             geom,
-            dqToConstrain, # dq_adjust_frozen,
-            op.Params.print_lvl - 1,  # suppress printing
+            constrained_dq, # dq_adjust_frozen,
+            print_lvl - 1,  # suppress printing
             bt_dx_conv=1.0e-12,
             bt_dx_rms_change_conv=1.0e-12,
             bt_max_iter=100,
         )
 
-        F.unfix_bend_axes()
+        frag.unfix_bend_axes()
 
         if frozen_conv:
             frozen_msg += "successful.\n"
@@ -283,15 +293,15 @@ def displace_frag(F, dq_in, ensure_convergence=False):
             logger.warning(frozen_msg)
 
     # Make sure final Dq is actual change
-    q_final = intcosMisc.q_values(F.intcos, geom)
+    q_final = intcosMisc.q_values(frag.intcos, geom)
     dq[:] = q_final - q_orig
 
-    if op.Params.print_lvl >= 1:
+    if print_lvl >= 1:
         frag_report = "\tReport of back-transformation: (au)\n"
         frag_report += "\n\t  int       q_final         q_target          Error\n"
         frag_report += "\t---------------------------------------------------\n"
         q_target = q_orig + dq_in
-        for i in range(F.num_intcos):
+        for i in range(frag.num_intcos):
             frag_report += "\t%5d%15.10lf%15.10f%15.10lf\n" % (
                 i + 1,
                 q_final[i],
@@ -308,20 +318,14 @@ def back_transformation(
     intcos,
     geom,
     dq,
-    print_lvl,
-    bt_dx_conv=None,
-    bt_dx_rms_change_conv=None,
-    bt_max_iter=None,
+    print_lvl=1,
+    bt_dx_conv=1e-7,
+    bt_dx_rms_change_conv=1.0e-12,
+    bt_max_iter=1.0e-6,
 ):
 
     dx_rms_last = -1
-    if bt_dx_conv is None:
-        bt_dx_conv = op.Params.bt_dx_conv
-    if bt_dx_rms_change_conv is None:
-        bt_dx_rms_change_conv = op.Params.bt_dx_rms_change_conv
-    if bt_max_iter is None:
-        bt_max_iter = op.Params.bt_max_iter
-
+    dq_rms, dx_rms, dx_max, best_dq_rms = 0.0, 0.0, 0.0, 0.0
     q_orig = intcosMisc.q_values(intcos, geom)
     q_target = q_orig + dq
 
@@ -335,6 +339,7 @@ def back_transformation(
                 dq[i],
             )
         logger.debug(target_step_str)
+    step_iter_str = ""
 
     if print_lvl > 0:
         step_iter_str = "\n\t             Back Transformation Report            "
@@ -352,7 +357,7 @@ def back_transformation(
     while bt_iter_continue:
 
         # dq_rms = rms(dq)
-        dx_rms, dx_max = dq_to_dx(intcos, geom, dq, print_lvl > 2)
+        dx_rms, dx_max = dq_to_dx(intcos, geom, dq, print_details=print_lvl > 2)
 
         # Met convergence thresholds
         if dx_rms < bt_dx_conv and dx_max < bt_dx_conv:
@@ -363,18 +368,18 @@ def back_transformation(
             bt_converged = False
             bt_iter_continue = False
 
-        dx_rms_last = dx_rms
-
         new_q = intcosMisc.q_values(intcos, geom)
         dq[:] = q_target - new_q
         del new_q
 
+        dx_rms_last = dx_rms
         dq_rms = rms(dq)
         if bt_iter_cnt == 0 or dq_rms < best_dq_rms:  # short circuit evaluation
             best_geom[:] = geom
             best_dq_rms = dq_rms
 
-        if print_lvl > 2:
+        # if print_lvl > 2:
+        if step_iter_str:
             step_iter_str += "\t%5d %14.1e %14.1e %14.1e\n" % (
                 bt_iter_cnt + 1,
                 dx_rms,
@@ -409,7 +414,7 @@ def back_transformation(
 # B (dx) = B * [Bt (B Bt)^-1 dq]
 #   dx = Bt (B Bt)^-1 dq
 #   dx = Bt G^-1 dq, where G = B B^t.
-def dq_to_dx(intcos, geom, dq, printDetails):
+def dq_to_dx(intcos, geom, dq, print_details, tol=1e-6):
     """Convert dq to dx.  Geometry is updated
 
     Parameters
@@ -418,6 +423,9 @@ def dq_to_dx(intcos, geom, dq, printDetails):
     geom : ndarray
         cartesian geometry updated to new geometry
     dq : displacement in internal coordinates
+    tol : float
+        tolerance for inversion of singular values. This argument corresponds to rcond in
+        numpy.linalg.pinv()
 
     Returns
     -------
@@ -428,16 +436,44 @@ def dq_to_dx(intcos, geom, dq, printDetails):
     """
     B = intcosMisc.Bmat(intcos, geom)
     G = B @ B.T
-    Ginv = symm_mat_inv(G, redundant=True, smallValLimit = op.Params.bt_pinv_rcond)
+    Ginv = symm_mat_inv(G, redundant=True, small_val_limit = tol)
     dx = B.T @ Ginv @ dq
 
-    if printDetails:
-        qOld = intcosMisc.q_values(intcos, geom)
+    # If the step in cartesian coordinates is irregularly large,
+    # recompute the step in internal coordinates with a more agressive check for small singular
+    # values in the B matrix
+    dq_len = np.linalg.norm(dq)
+    dx_len = np.linalg.norm(dx)
+    if dx_len > 10 * dq_len:
+
+        logger.debug(
+            "Cartesian step is %f times larger than internal coordinate step",
+            dx_len / dq_len
+        )
+
+        eigvals = np.linalg.eigvalsh(G)
+        largest = np.max(eigvals)
+        threshold = largest * tol
+        smallest = np.min(eigvals[eigvals > threshold])
+        new_threshold = (smallest/largest + 1e-10)
+
+        # recompute step
+        Ginv = symm_mat_inv(G, redundant = True, small_val_limit=new_threshold)
+        dx = B.T @ Ginv @ dq
+
+        if np.linalg.norm(dx) > 10 * dq_len:
+            raise OptError(
+                "Back transformation failed. Cartesian Step size too large. Please restart from "
+                "the most recent geometry"
+            )
+
+    if print_details:
+        q_old = intcosMisc.q_values(intcos, geom)
 
     geom += dx.reshape(geom.shape)
 
-    if printDetails:
-        dq_achieved = intcosMisc.q_values(intcos, geom) - qOld
+    if print_details:
+        dq_achieved = intcosMisc.q_values(intcos, geom) - q_old
         displacement_str = "\n\t      Report of Single-step\n"
         displacement_str += "\t  int       dq_achieved     deviation from target\n"
         for i in range(len(intcos)):

--- a/optking/exceptions.py
+++ b/optking/exceptions.py
@@ -16,9 +16,15 @@ class OptError(Exception):
 
 class AlgError(Exception):
     # maybe generalize later def __init__(self, *args, **kwargs):
-    def __init__(self, mesg="None given", newLinearBends=None):
+    def __init__(self, mesg="None given", new_linear_bends=[], new_linear_torsion=[], oofp_failures=[]):
         optimize_log.error(f"AlgError: Exception created. Mesg: {mesg}")
-        if newLinearBends:
-            optimize_log.error("AlgError: New bends detected.\n")
-        self.linearBends = newLinearBends
+        if new_linear_bends:
+            optimize_log.error("AlgError: Linear bends detected.\n%s", '\n'.join(map(str, new_linear_bends)))
+        if new_linear_torsion:
+            optimize_log.error("AlgError: Linear Torsions Detected\n%s", '\n'.join(map(str, new_linear_torsion)))
+        if oofp_failures:
+            optimize_log.error("AlgError: Linear Oofps Detected\n%s", '\n'.join(map(str, oofp_failures)))
+        self.linear_bends = new_linear_bends
+        self.linear_torsions = new_linear_torsion
+        self.oofp_failures = oofp_failures
         self.mesg = mesg

--- a/optking/history.py
+++ b/optking/history.py
@@ -12,7 +12,6 @@ from .molsys import Molsys
 from .linearAlgebra import abs_max, rms, sign_of_double
 from .printTools import print_array_string, print_mat_string
 from . import log_name
-from optking import molsys
 
 logger = logging.getLogger(f"{log_name}{__name__}")
 

--- a/optking/intcosMisc.py
+++ b/optking/intcosMisc.py
@@ -39,9 +39,9 @@ def Bmat(intcos, geom, masses=None):
 def tors_contains_bend(b, t):
     return b.atoms in [
         t.atoms[0:3],
-        list(reversed(t.atoms[0:3])),
+        t.atoms[3::-1],
         t.atoms[1:4],
-        list(reversed(t.atoms[1:4])),
+        t.atoms[4:0:-1],
     ]
 
 

--- a/optking/linearAlgebra.py
+++ b/optking/linearAlgebra.py
@@ -1,11 +1,10 @@
 import logging
-from math import fabs, sqrt
+from math import sqrt
 
 import numpy as np
 from numpy.linalg import LinAlgError
 
 from .exceptions import OptError
-from .printTools import print_array_string
 from . import log_name
 
 logger = logging.getLogger(f"{log_name}{__name__}")
@@ -106,7 +105,7 @@ def asymm_mat_eig(mat):
     return evals.real, evects.real.T
 
 
-def symm_mat_inv(A, redundant=False, smallValLimit=1.0e-10):
+def symm_mat_inv(A, redundant=False, small_val_limit=1.0e-10):
     """
     Return the inverse of a real, symmetric matrix.
 
@@ -138,12 +137,12 @@ def symm_mat_inv(A, redundant=False, smallValLimit=1.0e-10):
                     raise OptError("symm_mat_inv: could not compute eigenvectors")
 
                 absEvals = np.abs(evals)
-                threshold = smallValLimit * np.max(absEvals)
+                threshold = small_val_limit * np.max(absEvals)
                 logger.debug("Singular | values | > %8.3e will be inverted." % threshold)
                 val = np.min(absEvals[absEvals > threshold])
                 logger.debug("Smallest inverted value is %8.3e." % val)
 
-            return np.linalg.pinv(A, rcond=smallValLimit)
+            return np.linalg.pinv(A, rcond=small_val_limit)
 
         else:
             return np.linalg.inv(A)

--- a/optking/linesearch.py
+++ b/optking/linesearch.py
@@ -60,6 +60,7 @@ class LineSearch(OptimizationInterface):
         self.step_size = params.linesearch_step
         if params.linesearch_step is None:
             self.step_size = np.linalg.norm(self.history[-2].Dq) / 2
+        self.print_lvl = params.print_lvl
 
     def to_dict(self):
 
@@ -133,7 +134,13 @@ class LineSearch(OptimizationInterface):
             delta_energy = 0
 
         self.molsys.interfrag_dq_discontinuity_correction(dq)
-        achieved_dq, achieved_dx, return_str = displace_molsys(self.molsys, dq, fq, return_str=True)
+        achieved_dq, achieved_dx, return_str = displace_molsys(
+            self.molsys,
+            dq,
+            fq,
+            return_str=True,
+            print_lvl=self.print_lvl
+        )
         achieved_dq_norm = np.linalg.norm(achieved_dq)
         logger.info("\tNorm of achieved step-size %15.10f" % achieved_dq_norm)
 

--- a/optking/oofp.py
+++ b/optking/oofp.py
@@ -6,6 +6,7 @@ import qcelemental as qcel
 from . import optparams as op
 from . import v3d
 from . import log_name
+from . import bend
 from .exceptions import AlgError
 from .misc import string_math_fx
 from .simple import Simple
@@ -118,6 +119,10 @@ class Oofp(Simple):
     @property
     def f_show_factor(self):
         return qcel.constants.hartree2aJ * math.pi / 180.0
+
+    @property
+    def bends(self):
+        return [bend.Bend(self.A, self.B, self.C), bend.Bend(self.A, self.B, self.D), bend.Bend(self.C, self.B, self.D)]
 
     def to_dict(self):
         d = {}

--- a/optking/optimize.py
+++ b/optking/optimize.py
@@ -68,11 +68,11 @@ def optimize(o_molsys, computer):
                 dq = opt_object.take_step(fq, H, energy, return_str=False)
                 converged = opt_object.converged(energy, fq, dq)
                 opt_object.check_maxiter()  # raise error otherwise continue
-
             except AlgError as AF:
-                if H == 0 or fq == 0:
+                if isinstance(H, int) or isinstance(fq, int):
                     raise OptError("Failed to compute Hessian and Forces")
                 opt_object.alg_error_handler(H, fq, AF)
+                H = opt_object.H
         qc_output = opt_object.finish(error=None)
         return qc_output
 
@@ -337,7 +337,7 @@ class OptimizationManager(stepAlgorithms.OptimizationInterface):
         self.protocol = {"protocol": None, "step_number": step_number}
 
         if "hessian" not in self.opt_method.requires():
-            self.protocol.update({"protocol": "uneeded"})
+            self.protocol.update({"protocol": "unneeded"})
             return self.protocol
 
         if self.erase_hessian is True:
@@ -541,7 +541,7 @@ def get_pes_info(
 
     if hessian_protocol == "update":
         # For update. Compute new gradient. Update with external forces if present. Update the hessian
-        logger.info(f"Updating Hessian with {str(op.Params.hess_update)}")
+        logger.info(f"Updating Hessian with {str(params.hess_update)}")
         result = computer.compute(o_molsys.geom, driver=driver, return_full=False)
         g_x = np.asarray(result) if driver == "gradient" else None
         f_q = o_molsys.gradient_to_internals(g_x, -1.0)

--- a/optking/optimize.py
+++ b/optking/optimize.py
@@ -455,6 +455,7 @@ def optimization_factory(method, molsys, history_object, params=None):
         "SD": stepAlgorithms.SteepestDescent,
         "IRC": IRCfollowing.IntrinsicReactionCoordinate,
         "CONJUGATE": stepAlgorithms.ConjugateGradient,
+        "RS_I_RFO": stepAlgorithms.ImageRFO,
     }
 
     return ALGORITHMS.get(method, stepAlgorithms.RestrictedStepRFO)(molsys, history_object, params)

--- a/optking/optparams.py
+++ b/optking/optparams.py
@@ -8,7 +8,9 @@ import logging
 
 from .exceptions import AlgError, OptError
 from .misc import int_float_list, int_fx_string, int_list, int_xyz_float_list, int_xyz_fx_string, tokenize_input_string
+from . import log_name
 
+logger = logging.getLogger(f"{log_name}{__name__}")
 
 # Class for enumerated string options.
 def string_option(storage_name):
@@ -28,6 +30,7 @@ def string_option(storage_name):
 allowedStringOptions = {
     "opt_type": ("MIN", "TS", "IRC"),
     "step_type": ("RFO", "P_RFO", "NR", "SD", "LINESEARCH", "CONJUGATE"),
+    "step_type": ("RFO", "RS_I_RFO", "P_RFO", "NR", "SD", "LINESEARCH", "CONJUGATE"),
     "opt_coordinates": (
         "REDUNDANT",
         "INTERNAL",

--- a/optking/optparams.py
+++ b/optking/optparams.py
@@ -29,7 +29,6 @@ def string_option(storage_name):
 # The keys on the left here should be lower-case, as should the storage name of the property.
 allowedStringOptions = {
     "opt_type": ("MIN", "TS", "IRC"),
-    "step_type": ("RFO", "P_RFO", "NR", "SD", "LINESEARCH", "CONJUGATE"),
     "step_type": ("RFO", "RS_I_RFO", "P_RFO", "NR", "SD", "LINESEARCH", "CONJUGATE"),
     "opt_coordinates": (
         "REDUNDANT",
@@ -366,7 +365,8 @@ class OptParams(object):
         # Assume RFO means P-RFO for transition states.
         if self.opt_type == "TS":
             if self.step_type == "RFO" or "STEP_TYPE" not in uod:
-                self.step_type = "P_RFO"
+                self.step_type = "RS_I_RFO"
+                self.intrafrag_trust = 0.2
 
         if "GEOM_MAXITER" not in uod:
             if self.opt_type == "IRC":

--- a/optking/simple.py
+++ b/optking/simple.py
@@ -68,7 +68,6 @@ class Simple(ABC):
 
     @property
     def ext_force(self):
-        print(type(self._ext_force))
         return self._ext_force
 
     # could add checking here later

--- a/optking/stepAlgorithms.py
+++ b/optking/stepAlgorithms.py
@@ -1264,8 +1264,10 @@ def step_matches_forces(dq: np.ndarray, fq: np.ndarray):
 
     # Check for eigenvector values (dq) that are are non-zero where
     # the correspinding forces for that coordinate are zero
-    indices = np.argwhere(np.abs(fq) < 1e-10)
-    if not np.allclose(dq[indices], 0.0):
+    indices = np.argwhere(np.abs(fq) < 1e-12)
+    if not np.allclose(dq[indices], 0.0, rtol=0.0, atol=1e-4):
+        logger.debug("The step has a non-zero component along a coordinate with near-zero force %s",
+                     print_array_string(dq, form=":10.12f"))
         return False
 
     return True

--- a/optking/stepAlgorithms.py
+++ b/optking/stepAlgorithms.py
@@ -175,7 +175,12 @@ class OptimizationAlgorithm(OptimizationInterface):
 
         self.molsys.interfrag_dq_discontinuity_correction(dq)
         achieved_dq, achieved_dx, return_str = displace_molsys(
-            self.molsys, dq, fq, ensure_convergence=self.params.ensure_bt_convergence, return_str=return_str
+            self.molsys,
+            dq,
+            fq,
+            ensure_convergence=self.params.ensure_bt_convergence,
+            return_str=return_str,
+            print_lvl=self.params.print_lvl
         )
         dq_norm, unit_dq, projected_fq, projected_hess = self.step_metrics(achieved_dq, fq, H)
         delta_energy = self.expected_energy(dq, fq, H)

--- a/optking/tests/test_dimers_mt_tyr_Rscan.py
+++ b/optking/tests/test_dimers_mt_tyr_Rscan.py
@@ -7,10 +7,16 @@ import numpy as np
 import pytest
 import qcelemental as qcel
 
+from qcengine.testing import has_program
+
 au2kcal = qcel.constants.hartree2kcalmol
 
 
 @pytest.mark.dimers
+@pytest.mark.skipif(
+    (has_program("dftd3") or has_program("s-dftd3")) is False,
+    reason="Neither DFTD3 nor s-DFTD3 is findable"
+)
 def test_dimers_mt_tyr_Rscan():
     init_xyz = """
         C       -1.258686      0.546935      0.436840

--- a/optking/tests/test_dimers_mt_tyr_frozen_orientation.py
+++ b/optking/tests/test_dimers_mt_tyr_frozen_orientation.py
@@ -6,12 +6,16 @@ import optking
 
 # import numpy as np
 import pytest
-import qcelemental as qcel
-import qcengine as qcng
-
+# import qcelemental as qcel
+# import qcengine as qcng
+from qcengine.testing import has_program
 
 @pytest.mark.long
 @pytest.mark.dimers
+@pytest.mark.skipif(
+    (has_program("dftd3") or has_program("s-dftd3")) is False,
+    reason="Neither DFTD3 nor s-DFTD3 is findable"
+)
 def test_dimers_mt_tyr_frozen_orientation():
     # Starting at R ~ 5 Angstroms
     init_xyz = """

--- a/optking/tests/test_hf_g_opt.py
+++ b/optking/tests/test_hf_g_opt.py
@@ -114,4 +114,4 @@ def test_hf_g_ketene(check_iter):
     E = result["energies"][-1]  # TEST
     REF_energy = -151.7410313803  # TEST
     assert psi4.compare_values(REF_energy, E, 8, "RHF energy")  # TEST
-    utils.compare_iterations(result, 7, check_iter)
+    utils.compare_iterations(result, 8, check_iter)

--- a/optking/tests/test_oofp.py
+++ b/optking/tests/test_oofp.py
@@ -61,7 +61,7 @@ def test_ranged_oofp(check_iter):
     E = result["energies"][-1]
 
     assert psi4.compare_values(b3lyp_ranged_oop_30_energy, E, 5, "B3LYP energy")
-    utils.compare_iterations(result, 16, check_iter)
+    utils.compare_iterations(result, 3, check_iter)
 
 
 def test_ext_force_oofp(check_iter):

--- a/optking/tests/test_ranged_internals.py
+++ b/optking/tests/test_ranged_internals.py
@@ -6,7 +6,7 @@ import optking
 from .utils import utils
 
 conv_RHF_OO_at_135 = -150.7853238  # minimum is 1.39
-init_OO_distance = [("1.28", 9), ("1.30", 8), ("1.325", 8), ("1.35", 9), ("1.38", 8)]
+init_OO_distance = [("1.28", 9), ("1.30", 7), ("1.325", 8), ("1.35", 9), ("1.38", 8)]
 
 @pytest.mark.parametrize("option, num_steps", init_OO_distance)
 def test_ranged_stretch(option, num_steps, check_iter):

--- a/optking/tests/test_ts_opt.py
+++ b/optking/tests/test_ts_opt.py
@@ -1,10 +1,12 @@
 import psi4
 import optking
+import pytest
 
 from .utils import utils
 
 #! Optimization to 180 degree torsion from 120
-def test_hooh_TS(check_iter):
+@pytest.mark.parametrize("option, expected_steps", [("P_RFO", 14), ("RS_I_RFO", 10)])
+def test_hooh_TS(check_iter, option, expected_steps):
 
     hooh = psi4.geometry(
         """
@@ -21,6 +23,7 @@ def test_hooh_TS(check_iter):
         "basis": "cc-pvdz",
         "geom_maxiter": 30,
         "opt_type": "TS",
+        "step_type": option,
         "scf_type": "pk",
         "docc": [5, 4],
         "intrafrag_step_limit": 0.1,
@@ -34,11 +37,12 @@ def test_hooh_TS(check_iter):
     # print( '{:15.10f}'.format(E) )
     C2H_TS_ENERGY = -150.7854114803  # TEST
     assert psi4.compare_values(C2H_TS_ENERGY, E, 6, "RHF Energy after optimization to C2H TS")  # TEST
-    utils.compare_iterations(json_output, 14, check_iter)
+    utils.compare_iterations(json_output, expected_steps, check_iter)
 
 
 #! Optimization to 0 degree torsion from 100
-def test_hooh_TS_zero(check_iter):
+@pytest.mark.parametrize("option, expected_steps", [("P_RFO", 21), ("RS_I_RFO", 10)])
+def test_hooh_TS_zero(check_iter, option, expected_steps):
 
     hooh = psi4.geometry(
         """
@@ -55,6 +59,7 @@ def test_hooh_TS_zero(check_iter):
         "basis": "cc-pvdz",
         "geom_maxiter": 40,
         "opt_type": "TS",
+        "step_type": option,
         "scf_type": "pk",
         "docc": [5, 4],
         "intrafrag_step_limit": 0.1,
@@ -67,7 +72,7 @@ def test_hooh_TS_zero(check_iter):
     E = json_output["energies"][-1]  # TEST
     C2V_TS_ENERGY = -150.774009217562  # TEST
     assert psi4.compare_values(C2V_TS_ENERGY, E, 6, "RHF Energy after optimization to C2H TS")  # TEST
-    utils.compare_iterations(json_output, 21, check_iter)
+    utils.compare_iterations(json_output, expected_steps, check_iter)
 
 
 def test_hooh_min(check_iter):

--- a/optking/tors.py
+++ b/optking/tors.py
@@ -6,6 +6,7 @@ import qcelemental as qcel
 
 from . import optparams as op
 from . import v3d
+from . import bend
 from .exceptions import AlgError, OptError
 from .misc import hguess_lindh_rho, string_math_fx
 from .simple import Simple
@@ -149,12 +150,16 @@ class Tors(Simple):
             ext_force = string_math_fx(fstr)
         return cls(a, b, c, d, constraint, near180, range_min, range_max, ext_force)
 
+    @property
+    def bends(self):
+        return [bend.Bend(*self.atoms[:-1]), bend.Bend(*self.atoms[1:])]
+
     # compute angle and return value in radians
     def q(self, geom):
         try:
             tau = v3d.tors(geom[self.A], geom[self.B], geom[self.C], geom[self.D])
         except AlgError as error:
-            raise AlgError("Tors.q: unable to compute torsion value") from error
+            raise AlgError("Tors.q: unable to compute torsion value", new_linear_torsion=[self]) from error
 
         # Extend values domain of torsion angles beyond pi or -pi, so that
         # delta(values) can be calculated


### PR DESCRIPTION
The TS state code I was holding onto. Restricted Step Image Rational Function Optimization with miscellaneous fixes and tweaks to get the full Baker 1996 (not just Helgaker's subset) running smoothly.

The new algorithm isn't clearly superior to the existing in every way. I have a subset of the test results here:
[TS results.ods](https://github.com/user-attachments/files/16069626/TS.results.ods)

The new algorithm has a few less molecules that it typically struggles with compared to the `P_RFO` but neither is perfect. Most of the molecules the `RS_I_RFO` struggles with are primarly due to bad coordinate sets (STETRAZINE being the notable exception - I don't see anything noticeably wrong with those coordinates) i.e. in diels alder the two fragments are connected with stretches between C and H atoms instead of the carbon atoms where bonds are being formed. `P_RFO` tends to have more difficulty with symmetry breaking but I didn't deep dive into every `P_RFO` failure some I'm not sure what went wrong. `P_RFO` seems to often converge in 1 fewer steps than `RS_I_RFO`.

Tests currently failing because the new method isn't recognized by Psi4.