### PR TITLE
Adds freeze_all_dihedrals option

### DIFF
--- a/optking/optparams.py
+++ b/optking/optparams.py
@@ -190,6 +190,12 @@ class OptParams(object):
         frozen = uod.get("FROZEN_CARTESIAN", "")
         self.frozen_cartesian = int_xyz_float_list(tokenize_input_string(frozen), 1, 1, 0)
 
+        # constrain ALL torsions to be frozen.
+        self.freeze_all_dihedrals = uod.get("FREEZE_ALL_DIHEDRALS", False)
+        # For use only with `freeze_all_dihedrals` unfreeze a small subset of dihedrals
+        frozen = uod.get("UNFREEZE_DIHEDRALS", "")
+        self.unfreeze_dihedrals = int_list(tokenize_input_string(frozen), 4)
+
         # Specify distance between atoms to be ranged
         ranged = uod.get("RANGED_DISTANCE", "")
         self.ranged_distance = int_float_list(tokenize_input_string(ranged), 2, 2)


### PR DESCRIPTION
I've been experiencing some git history issues where commits from image_rfo have been getting duplicated and show up as 'n' extra commits. I'm not sure if this is an issue with a squash or rebase performed on that branch. This commit was manually extracted from another, larger PR.