### PR TITLE
Update molsys.py

### DIFF
--- a/optking/molsys.py
+++ b/optking/molsys.py
@@ -541,7 +541,7 @@ class Molsys(object):
         if self.nfragments == 1:
             return
 
-        frag_connectivity = np.zeros((nF, nF))
+        frag_connectivity = np.zeros((nF, nF), dtype=int)
         for iF in range(nF):
             frag_connectivity[iF, iF] = 1
 
@@ -590,7 +590,7 @@ class Molsys(object):
                                 C[i][j] = C[j][i] = True
 
             # Test whether all frags are connected using current distance threshold
-            if np.sum(frag_connectivity[0]) == nF:
+            if any(np.sum(frag_connectivity, axis=0) - nF == 0):
                 logger.info("\tAll fragments are connected in connectivity matrix.")
                 all_connected = True
             else:


### PR DESCRIPTION
Fixes bug when creating a single fragment from more than two. Currently, given three atoms A-B-C, connectivity is expanded until A is directly connected to B and C even if A-B and B-C have already been connected. Addresses #105