### PR TITLE
Updates some parameters

### DIFF
--- a/optking/tests/test_frozen_internals.py
+++ b/optking/tests/test_frozen_internals.py
@@ -56,7 +56,7 @@ def test_frozen_coords(option, expected, num_steps, check_iter):
     assert psi4.compare_values(expected, thisenergy, 6)  # TEST
     utils.compare_iterations(json_output, num_steps, check_iter)
 
-
+@pytest.mark.pubchem
 def test_butane_frozen(check_iter):
     _ = psi4.geometry("pubchem:butane")
 
@@ -114,7 +114,7 @@ def test_butane_frozen(check_iter):
     assert psi4.compare_values(E1, E2, 8, "RHF energy")  # TEST
     utils.compare_iterations(result, 5, check_iter)
 
-
+@pytest.mark.pubchem
 def test_butane_skip_frozen(check_iter):
     _ = psi4.geometry("pubchem:butane")
 

--- a/optking/v1/optparams.py
+++ b/optking/v1/optparams.py
@@ -87,7 +87,7 @@ class OptParams(BaseModel):
     logging level from the command line. ``psi4 --loglevel=10...``"""
 
     # Print all optimization parameters.
-    printxopt_params: bool = False
+    # printxopt_params: bool = False
     # output_type: str = Field(pattern=r"FILE|STDOUT|NULL", default="FILE")
 
     # Specifies minimum search, transition-state search, or IRC following
@@ -163,8 +163,9 @@ class OptParams(BaseModel):
 
     # Whether to accept geometry steps that lower the molecular point group. DEFAULT=False
     accept_symmetry_breaking: bool = False
-    """Whether to accept steps that lower the molecular point group. Note - as of 0.3.0,
-    this is **only** effective when running through Psi4"""
+    """Whether to accept steps that lower the molecular point group. Within optking this check is
+    not rigorous and if the only reasonable step is symmetry breaking it will be taken. This keyword
+    affects optking's symmetrization not Psi4's"""
 
     # TODO This needs a validator to check the allowed values as well as set dynamic_lvl_max depending
     # upon dynamic_lvl
@@ -257,7 +258,7 @@ class OptParams(BaseModel):
     """Upper bound for dynamic trust radius [au]"""
 
     # Initial maximum step size in bohr or radian along an interfragment coordinate
-    interfrag_trust: float = Field(gt=0.0, default=0.5)
+    interfrag_trust: float = Field(gt=0.0, default=0.5, alias="INTERFRAG_STEP_LIMIT")
     """Initial maximum step size in bohr or radian along an interfragment coordinate"""
 
     # Lower bound for dynamic trust radius [a/u] for interfragment coordinates

--- a/optking/v2/optparams.py
+++ b/optking/v2/optparams.py
@@ -98,7 +98,7 @@ class OptParams(BaseModel):
     as Psi4 change the logging level from the command line. `psi4 --loglevel=10...`"""
 
     # Print all optimization parameters.
-    printxopt_params: bool = False
+    # printxopt_params: bool = False
     # output_type: str = Field(pattern=r"FILE|STDOUT|NULL", default="FILE")
 
     # Specifies minimum search, transition-state search, or IRC following
@@ -175,8 +175,9 @@ class OptParams(BaseModel):
 
     # Whether to accept geometry steps that lower the molecular point group. DEFAULT=False
     accept_symmetry_breaking: bool = False
-    """Whether to accept geometry steps that lower the molecular point group. Note - as of 0.3.0,
-    this is only effective when running through Psi4"""
+    """Whether to accept steps that lower the molecular point group. Within optking this check is
+    not rigorous and if the only reasonable step is symmetry breaking it will be taken. This keyword
+    affects optking's symmetrization not Psi4's"""
 
     # TODO This needs a validator to check the allowed values as well as set dynamic_lvl_max depending
     # upon dynamic_lvl
@@ -269,7 +270,7 @@ class OptParams(BaseModel):
     """Upper bound for dynamic trust radius [au]"""
 
     # Initial maximum step size in bohr or radian along an interfragment coordinate
-    interfrag_trust: float = Field(gt=0.0, default=0.5)
+    interfrag_trust: float = Field(gt=0.0, default=0.5, alias="INTERFRAG_STEP_LIMIT")
     """Initial maximum step size in bohr or radian along an interfragment coordinate"""
 
     # Lower bound for dynamic trust radius [a/u] for interfragment coordinates


### PR DESCRIPTION
Found some keyword inconsistencies when finishing Psi4 PR.

- [x] Add alias to `interfrag_trust` so it matches other keywords
- [x] Correct accept_symmetry_breaking description
- [x] remove printxopt_params - we don't check it.
- [x] Adds pytest,mark.pubchem to allow for lack on internet on Fedora builds. #101

test time should already have been addressed; however, current pytest -n 4 -m "not long" -m "not pubchem" takes less than 4 minutes on my machine